### PR TITLE
fix(ci): prevent caddy healthcheck from failing deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -114,7 +114,9 @@ jobs:
             docker compose run --rm -w /app/services/map map node dist/db/migrate.js
 
             echo "==> Restarting services"
-            docker compose up -d --wait --timeout 120
+            docker compose up -d --wait --timeout 120 postgres redis qdrant identity market guide-booking map ai gateway
+            # Start caddy without --wait (health depends on DNS/TLS — non-blocking)
+            docker compose up -d caddy
 
             echo "==> Cleaning up old images"
             docker image prune -f

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -210,10 +210,11 @@ services:
     depends_on:
       - gateway
     healthcheck:
-      test: ['CMD', 'wget', '--spider', '-q', 'http://localhost:2019/config/']
+      test: ['CMD-SHELL', 'wget -qO /dev/null http://localhost:2019/config/ 2>/dev/null']
       interval: 15s
       timeout: 10s
       retries: 5
+      start_period: 30s
     networks:
       - hena-internal
 


### PR DESCRIPTION
## Summary

- Fixed Caddy healthcheck: `wget --spider` (HEAD) → `wget -qO /dev/null` (GET) — Caddy admin API may not handle HEAD on `/config/`
- Added `start_period: 30s` to Caddy healthcheck for initialization grace
- Deploy now waits only on app services (`--wait` targets specific services), starts Caddy separately without blocking — Caddy depends on DNS/TLS being configured which is external to the deploy

## Root cause

`docker compose up -d --wait --timeout 120` checks ALL services for health. Caddy was already running and unhealthy (from before the deploy), so `--wait` failed immediately — taking down the entire deploy even though all NestJS services were healthy.

## Test plan

- [ ] Merge to main and verify the deploy workflow passes
- [ ] Verify NestJS services come up healthy on VPS
- [ ] Caddy remains started (just not waited on) — will become healthy once DNS A record is configured