### PR TITLE
chore(ci): bump actions to Node.js 24

### DIFF
--- a/.github/actions/setup-node-pnpm/action.yml
+++ b/.github/actions/setup-node-pnpm/action.yml
@@ -4,7 +4,7 @@ description: Install pnpm, setup Node.js, and install dependencies
 runs:
   using: composite
   steps:
-    - uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4.2.0
+    - uses: pnpm/action-setup@b307475762933b98ed359c036b0e51f26b63b74b # v5.0.0
     - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
       with:
         node-version: '22'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -50,17 +50,17 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Log in to GHCR
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
+        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
       - name: Build and push
-        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
+        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
         with:
           context: ${{ matrix.context }}
           file: ${{ matrix.context }}/${{ matrix.dockerfile }}


### PR DESCRIPTION
## Summary

- Bumps 4 GitHub Actions from Node.js 20 to Node.js 24 runtime to resolve deprecation warnings
- `pnpm/action-setup` v4.2.0 → v5.0.0
- `docker/login-action` v3.7.0 → v4.0.0
- `docker/setup-buildx-action` v3.12.0 → v4.0.0
- `docker/build-push-action` v6.19.2 → v7.0.0

## Why

Node.js 20 actions are deprecated. GitHub will force-migrate to Node.js 24 on **June 2, 2026** and remove Node.js 20 entirely on September 16, 2026. All four bumps are runtime-only upgrades with no interface changes.

## Test plan

- [ ] CI pipeline passes (the CI workflow itself uses `pnpm/action-setup` — this validates it works on Node 24)
- [ ] Merge and verify deploy pipeline runs without Node.js 20 warnings