### PR TITLE
fix(ci): override path-to-regexp to resolve high severity vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
     "overrides": {
       "fast-xml-parser": ">=5.5.6",
       "flatted": ">=3.4.2",
-      "picomatch": ">=4.0.4"
+      "picomatch": ">=4.0.4",
+      "path-to-regexp": ">=8.4.0"
     }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,7 @@ overrides:
   fast-xml-parser: '>=5.5.6'
   flatted: '>=3.4.2'
   picomatch: '>=4.0.4'
+  path-to-regexp: '>=8.4.0'
 
 importers:
 
@@ -5088,8 +5089,8 @@ packages:
     resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
     engines: {node: '>=16 || 14 >=14.18'}
 
-  path-to-regexp@8.3.0:
-    resolution: {integrity: sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==}
+  path-to-regexp@8.4.0:
+    resolution: {integrity: sha512-PuseHIvAnz3bjrM2rGJtSgo1zjgxapTLZ7x2pjhzWwlp4SJQgK3f3iZIQwkpEnBaKz6seKBADpM4B4ySkuYypg==}
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
@@ -7175,7 +7176,7 @@ snapshots:
       '@nuxt/opencollective': 0.4.1
       fast-safe-stringify: 2.1.1
       iterare: 1.2.1
-      path-to-regexp: 8.3.0
+      path-to-regexp: 8.4.0
       reflect-metadata: 0.2.2
       rxjs: 7.8.2
       tslib: 2.8.1
@@ -7201,7 +7202,7 @@ snapshots:
       cors: 2.8.6
       express: 5.2.1
       multer: 2.1.1
-      path-to-regexp: 8.3.0
+      path-to-regexp: 8.4.0
       tslib: 2.8.1
     transitivePeerDependencies:
       - supports-color
@@ -10927,7 +10928,7 @@ snapshots:
       lru-cache: 10.4.3
       minipass: 7.1.3
 
-  path-to-regexp@8.3.0: {}
+  path-to-regexp@8.4.0: {}
 
   pathe@2.0.3: {}
 
@@ -11323,7 +11324,7 @@ snapshots:
       depd: 2.0.0
       is-promise: 4.0.0
       parseurl: 1.3.3
-      path-to-regexp: 8.3.0
+      path-to-regexp: 8.4.0
     transitivePeerDependencies:
       - supports-color
 


### PR DESCRIPTION
## Summary

- **Root cause:** `pnpm audit --audit-level=high` fails in CI because `path-to-regexp@8.3.0` (transitive dep via `@nestjs/core@11.1.16`) has a high severity DoS vulnerability ([GHSA-j3q9-mxjg-w52f](https://github.com/advisories/GHSA-j3q9-mxjg-w52f))
- **Fix:** Added `"path-to-regexp": ">=8.4.0"` to `pnpm.overrides` in root `package.json` — same pattern already used for `fast-xml-parser`, `flatted`, and `picomatch`
- **Why not upgrade NestJS?** `@nestjs/core@11.1.17` (latest) still pins `path-to-regexp@8.3.0`

## Test plan

- [x] `pnpm audit --audit-level=high` exits 0 locally
- [x] `pnpm build` succeeds
- [x] All 353 tests pass (`pnpm test`)
- [ ] CI Security Audit job passes on this PR

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Overrides `path-to-regexp` to `>=8.4.0` via `pnpm.overrides` to fix the high‑severity DoS in `8.3.0` (transitive via `@nestjs/core`) and unblock the CI security audit. `@nestjs/core@11.1.17` still pins `8.3.0`, so we override instead of upgrading.

<sup>Written for commit e241ea34170038fb6b5a7d47174c0bf694879b1c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

