### PR TITLE
fix(deployment fix): deploy conf after chatbot

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -78,13 +78,21 @@ jobs:
     environment: production
     timeout-minutes: 10
     steps:
+      - name: Validate required deploy secrets
+        run: |
+          : "${MONGO_INITDB_ROOT_USERNAME:?MONGO_INITDB_ROOT_USERNAME is not set}"
+          : "${MONGO_INITDB_ROOT_PASSWORD:?MONGO_INITDB_ROOT_PASSWORD is not set}"
+        env:
+          MONGO_INITDB_ROOT_USERNAME: ${{ secrets.MONGO_INITDB_ROOT_USERNAME }}
+          MONGO_INITDB_ROOT_PASSWORD: ${{ secrets.MONGO_INITDB_ROOT_PASSWORD }}
+
       - name: Deploy via SSH
         uses: appleboy/ssh-action@0ff4204d59e8e51228ff73bce53f80d53301dee2 # v1.2.5
         with:
           host: ${{ secrets.SSH_HOST }}
           username: ${{ secrets.SSH_USER }}
           key: ${{ secrets.SSH_KEY }}
-          envs: GHCR_TOKEN,GHCR_USER,DEPLOY_SHA
+          envs: GHCR_TOKEN,GHCR_USER,DEPLOY_SHA,MONGO_INITDB_ROOT_USERNAME,MONGO_INITDB_ROOT_PASSWORD
           script: |
             set -euo pipefail
             cd /opt/hena-wadeena
@@ -100,6 +108,31 @@ jobs:
             git fetch origin main
             git checkout "$DEPLOY_SHA"
 
+            echo "==> Syncing MongoDB credentials into .env"
+            touch .env
+            upsert_env() {
+              local key="$1"
+              local value="$2"
+              awk -v k="$key" -v v="$value" '
+                BEGIN { updated = 0 }
+                $0 ~ "^" k "=" {
+                  print k "=" v
+                  updated = 1
+                  next
+                }
+                { print }
+                END {
+                  if (!updated) {
+                    print k "=" v
+                  }
+                }
+              ' .env > .env.tmp
+              mv .env.tmp .env
+            }
+            upsert_env "MONGO_INITDB_ROOT_USERNAME" "$MONGO_INITDB_ROOT_USERNAME"
+            upsert_env "MONGO_INITDB_ROOT_PASSWORD" "$MONGO_INITDB_ROOT_PASSWORD"
+            upsert_env "MONGODB_URI" "mongodb://$MONGO_INITDB_ROOT_USERNAME:$MONGO_INITDB_ROOT_PASSWORD@mongodb:27017/nakheel_db?authSource=admin"
+
             echo "==> Pulling images by SHA and tagging as :latest"
             for svc in identity market guide-booking map ai gateway; do
               docker pull "ghcr.io/$GHCR_USER/hena-wadeena/$svc:$DEPLOY_SHA"
@@ -107,7 +140,7 @@ jobs:
                 "ghcr.io/$GHCR_USER/hena-wadeena/$svc:latest"
             done
 
-            echo "==> Running migrations (sequential — shared drizzle tracking table)"
+            echo "==> Running migrations (sequential - shared drizzle tracking table)"
             docker compose run --rm -w /app/services/identity identity node dist/db/migrate.js
             docker compose run --rm -w /app/services/market market node dist/db/migrate.js
             docker compose run --rm -w /app/services/guide-booking guide-booking node dist/db/migrate.js
@@ -115,7 +148,7 @@ jobs:
 
             echo "==> Restarting services"
             docker compose up -d --wait --timeout 120 postgres redis qdrant identity market guide-booking map ai gateway
-            # Start caddy without --wait (health depends on DNS/TLS — non-blocking)
+            # Start caddy without --wait (health depends on DNS/TLS - non-blocking)
             docker compose up -d caddy
 
             echo "==> Cleaning up old images"
@@ -126,3 +159,5 @@ jobs:
           GHCR_TOKEN: ${{ secrets.GHCR_PAT }}
           GHCR_USER: ${{ github.repository_owner }}
           DEPLOY_SHA: ${{ github.sha }}
+          MONGO_INITDB_ROOT_USERNAME: ${{ secrets.MONGO_INITDB_ROOT_USERNAME }}
+          MONGO_INITDB_ROOT_PASSWORD: ${{ secrets.MONGO_INITDB_ROOT_PASSWORD }}

--- a/code-review-issues.md
+++ b/code-review-issues.md
@@ -1,113 +1,116 @@
-# New Unresolved Issues — Devin Review (2026-03-28)
+# Deployment Failure — Missing MongoDB Credentials
 
-> **3 new issues** discovered in the latest Devin Review pass.
-> Previously flagged issues have been marked ✅ resolved in the PR comments and are **not** included here.
-
----
-
-## Previously Resolved (for reference)
-
-| Issue | Status |
-|-------|--------|
-| `reranker.py` — scalar `compute_score` crashes `zip()` | ✅ Fixed — `isinstance(scores, list)` guard added |
-| `chat.py` — duplicate user message in LLM context | ✅ Fixed — `exclude_message_id` passed to `build_context_window` |
-| `ChatWidget.tsx` — infinite bootstrap retry loop | ✅ Fixed — `bootstrapError` guard added to `useEffect` |
-| `ChatWidget.tsx` — user message lost during session retry | ✅ Fixed — `bootstrapSession(true, { preserveMessages: true })` |
-| `documents.py` — unauthenticated document endpoints | ✅ Fixed — `get_current_user` dependency added to all endpoints |
+**Date:** 2026-03-28
+**Commit:** `21f8e33fba145d191697a883d30996d40eccbc2b` (PR #56 — addingChatBot)
+**Stage:** Deploy → Running migrations
+**Exit code:** 1
 
 ---
 
-## New Unresolved Issues
+## Error
 
----
-
-### 1. 🔴 Nginx gateway has no route for `/api/v1/documents/` — endpoints dead in production
-
-**File:** `gateway/nginx.conf.template:146`
-**Related:** `services/ai/nakheel/api/router.py:10`
-
-The PR registers a new `documents` router (prefix `/documents`) in the AI service, creating endpoints such as:
-- `POST /api/v1/documents/inject`
-- `POST /api/v1/documents/parse`
-- `GET /api/v1/documents/{doc_id}`
-- etc.
-
-However, the nginx gateway only routes requests matching `^/api/v1/(chat|ai)/` to the AI service. The `documents` prefix is not included, so all document management requests hit the default `location /` block and return a bare `404`. **All document endpoints are effectively dead in any production deployment using the nginx gateway.**
-
-**Suggested fix** — `gateway/nginx.conf.template:146`:
-```nginx
-# Before:
-location ~ ^/api/v1/(chat|ai)/ {
-
-# After:
-location ~ ^/api/v1/(chat|ai|documents)/ {
+```
+error while interpolating services.mongodb.environment.MONGO_INITDB_ROOT_USERNAME:
+required variable MONGO_INITDB_ROOT_USERNAME is missing a value:
+MONGO_INITDB_ROOT_USERNAME is not set
 ```
 
 ---
 
-### 2. 🟡 Audit log insert failure swallows the original delete error
+## Root Cause
 
-**File:** `services/ai/nakheel/api/endpoints/documents.py:203–216`
+The PR that added MongoDB authentication (fixing the P1 security issue flagged in the earlier code review) set `MONGO_INITDB_ROOT_USERNAME` and `MONGO_INITDB_ROOT_PASSWORD` as **required** environment variables in `docker-compose.yml`. However, those variables were never added to the server's `.env` file at `/opt/hena-wadeena/.env`.
 
-In the `delete_document` exception handler, if MongoDB is unreachable when the `document_delete_failed` audit log is being persisted, `insert_one` raises its own exception. This prevents the original `raise` from ever executing, so the caller and any error-tracking tools receive a misleading MongoDB connection error instead of the actual partial-delete failure.
+When the deploy script ran `docker compose run --rm ... identity node dist/db/migrate.js`, Docker Compose tried to interpolate all service definitions — including the new `mongodb` service — and failed immediately because the required variables had no value.
 
-**Current (broken) code:**
-```python
-except Exception as exc:
-    logger.exception("Partial delete failure for document {}", doc_id)
-    await mongo.collection("audit_logs").insert_one({
-        "event": "document_delete_failed",
-        ...
-        "error": str(exc),
-    })
-    raise  # ❌ never reached if insert_one fails
+**The deploy script uses `set -euo pipefail`**, so the first non-zero exit aborted the entire pipeline. No migrations ran and no services were restarted.
+
+---
+
+## Impact
+
+- **No services were restarted** — the currently running containers (from the previous deploy) are still up and serving traffic.
+- **No data was lost** — the migration step failed before any `docker compose up` commands executed.
+- **The new AI/chatbot features from PR #56 are not live yet.**
+
+---
+
+## Fix
+
+### Step 1 — Add the missing variables to the server's `.env` file
+
+SSH into the deployment server and append the two MongoDB credential variables to `/opt/hena-wadeena/.env`:
+
+```bash
+echo 'MONGO_INITDB_ROOT_USERNAME=<choose-a-username>' >> /opt/hena-wadeena/.env
+echo 'MONGO_INITDB_ROOT_PASSWORD=<choose-a-strong-password>' >> /opt/hena-wadeena/.env
 ```
 
-**Suggested fix:**
-```python
-except Exception as exc:
-    logger.exception("Partial delete failure for document {}", doc_id)
-    try:
-        await mongo.collection("audit_logs").insert_one({
-            "event": "document_delete_failed",
-            "doc_id": doc_id,
-            "created_at": deleted_at,
-            "partial_failure": True,
-            "qdrant_ids": qdrant_ids,
-            "qdrant_deleted": qdrant_deleted,
-            "error": str(exc),
-        })
-    except Exception:
-        pass  # audit log failure must not suppress the original error
-    raise  # ✅ always reached
+> **Security note:** Use a strong, randomly generated password. Do **not** reuse any existing service credentials. Store both values in your secrets manager (e.g., GitHub Actions secrets, Vault, or your team's password manager) immediately.
+
+### Step 2 — Also add the credentials to the AI service connection URI
+
+The MongoDB URI used by the AI service must include the credentials. Update `MONGODB_URI` in the same `.env` file:
+
+```bash
+# Replace the existing MONGODB_URI line:
+MONGODB_URI=mongodb://<username>:<password>@mongodb:27017
+```
+
+Or if you prefer to keep username/password as separate variables and compose the URI in config:
+
+```bash
+MONGODB_URI=mongodb://${MONGO_INITDB_ROOT_USERNAME}:${MONGO_INITDB_ROOT_PASSWORD}@mongodb:27017
+```
+
+### Step 3 — Re-trigger the deployment
+
+Once the `.env` file is updated, re-run the deployment. The fastest way is to re-run the failed GitHub Actions workflow from the Actions tab (no new commit needed).
+
+Alternatively, run the deploy commands manually on the server:
+
+```bash
+cd /opt/hena-wadeena
+
+# Run migrations
+docker compose run --rm -w /app/services/identity identity node dist/db/migrate.js
+docker compose run --rm -w /app/services/market market node dist/db/migrate.js
+docker compose run --rm -w /app/services/guide-booking guide-booking node dist/db/migrate.js
+docker compose run --rm -w /app/services/map map node dist/db/migrate.js
+
+# Restart services
+docker compose up -d --wait --timeout 120 \
+  postgres redis qdrant identity market guide-booking map ai gateway
+docker compose up -d caddy
 ```
 
 ---
 
-### 3. 🟡 Session restore shows the oldest 20 messages instead of the most recent
+## Prevention
 
-**File:** `apps/web/src/components/ai/ChatWidget.tsx:80`
+To avoid this class of failure in the future:
 
-When `ChatWidget` restores a session from `localStorage`, it calls `aiAPI.getSession(savedSessionId)` with default pagination (`page=1, perPage=20`). The backend sorts messages by `created_at` ascending and returns the **first** page — the oldest 20 messages. For any session with more than 20 messages (10+ back-and-forth exchanges, which is realistic given the 168-hour `SESSION_TTL_HOURS`), the user sees the beginning of their conversation but the most recent exchanges are missing.
+1. **Document all required env vars in `.env.example`** — `MONGO_INITDB_ROOT_USERNAME`, `MONGO_INITDB_ROOT_PASSWORD`, and the authenticated `MONGODB_URI` should already be present in `.env.example` after the auth fix. Verify they are.
 
-**Fix options (pick one):**
+2. **Add a pre-deploy env validation step** to the GitHub Actions deploy workflow that checks for required variables before SSHing to the server:
 
-**Option A — Simple:** Fetch a large batch to cover most sessions:
-```typescript
-const session = await aiAPI.getSession(savedSessionId, 1, 200);
+```yaml
+- name: Validate required secrets
+  run: |
+    : "${MONGO_INITDB_ROOT_USERNAME:?MONGO_INITDB_ROOT_USERNAME is not set}"
+    : "${MONGO_INITDB_ROOT_PASSWORD:?MONGO_INITDB_ROOT_PASSWORD is not set}"
+  env:
+    MONGO_INITDB_ROOT_USERNAME: ${{ secrets.MONGO_INITDB_ROOT_USERNAME }}
+    MONGO_INITDB_ROOT_PASSWORD: ${{ secrets.MONGO_INITDB_ROOT_PASSWORD }}
 ```
 
-**Option B — Correct pagination:** Use the pagination metadata to fetch the last page:
-```typescript
-const first = await aiAPI.getSession(savedSessionId, 1, 20);
-const totalPages = first.pagination.total_pages;
-const session = totalPages > 1
-  ? await aiAPI.getSession(savedSessionId, totalPages, 20)
-  : first;
-```
-> Note: with this approach, messages on the last page should be reversed for display if the sort order is ascending.
+3. **Store all service credentials in GitHub Actions secrets** and pass them to the deploy script via `envs:`, just as `GHCR_TOKEN` is handled today.
 
-**Option C — Backend change:** Add a `latest` mode to `session_manager.get_messages` that sorts descending and returns the most recent messages, then reverses them before returning to the client.
+---
+
+## Related
+
+- Original review issue: **P1 #4** — *MongoDB deployed without authentication in `docker-compose.yml`* (from `code-review-issues.md`)
 
 ---
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes production deploys by validating and wiring MongoDB credentials through the GitHub Actions workflow and into the server `.env`, composing `MONGODB_URI` so migrations and services start cleanly after the chatbot changes. Prevents the “MONGO_INITDB_ROOT_USERNAME is not set” error seen in previous runs.

- **Bug Fixes**
  - Add pre-flight secret checks for `MONGO_INITDB_ROOT_USERNAME` and `MONGO_INITDB_ROOT_PASSWORD` in `.github/workflows/deploy.yml`.
  - Forward these secrets via `appleboy/ssh-action` and upsert `MONGO_INITDB_ROOT_USERNAME`, `MONGO_INITDB_ROOT_PASSWORD`, and `MONGODB_URI` into `/opt/hena-wadeena/.env` before running migrations and `docker compose up`.

<sup>Written for commit 95b5a50ae09caca2f2165834223fa4faaf37eda0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

