### PR TITLE
fix(deploy): prevent .env corruption from awk escape sequences

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -117,20 +117,8 @@ jobs:
             upsert_env() {
               local key="$1"
               local value="$2"
-              awk -v k="$key" -v v="$value" '
-                BEGIN { updated = 0 }
-                $0 ~ "^" k "=" {
-                  print k "=" v
-                  updated = 1
-                  next
-                }
-                { print }
-                END {
-                  if (!updated) {
-                    print k "=" v
-                  }
-                }
-              ' .env > .env.tmp
+              grep -v "^${key}=" .env > .env.tmp || true
+              printf '%s=%s\n' "$key" "$value" >> .env.tmp
               mv .env.tmp .env
             }
             upsert_env "MONGO_INITDB_ROOT_USERNAME" "$MONGO_INITDB_ROOT_USERNAME"


### PR DESCRIPTION
## Summary

- The `upsert_env` function used `awk -v` to write secrets into `.env`, which interprets escape sequences (`\n` → newline, `\\` → `\`, etc.). Secrets containing backslashes or `#` got corrupted, causing the map service to fail env validation (`JWT_ACCESS_SECRET` too short) and crash-loop on deploy.
- Replaced with `grep -v` (remove old line) + `printf '%s=%s\n'` (append literal value), which preserves all characters verbatim.

## Test plan

- [ ] Merge and verify the deploy workflow passes on main
- [ ] Confirm map service starts healthy (`docker compose ps` shows `Up (healthy)`)
- [ ] Confirm `.env` on Contabo has correct, unmangled `JWT_ACCESS_SECRET`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent `.env` corruption in deploy by replacing the `awk -v` env upsert with a safe `grep -v` + `printf` approach. This preserves secrets with backslashes or `#` and stops the map service from failing env validation and crash-looping.

- **Bug Fixes**
  - Write env lines literally with `printf '%s=%s\n'` after removing the old key via `grep -v`, avoiding escape sequence interpretation.
  - Keep `JWT_ACCESS_SECRET` and other secrets intact on the server.

<sup>Written for commit 1a466a3835d5fb91c68efe3ddf8e79296e0efa59. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

