### PR TITLE
fix(gateway): resolve registration 500 and Caddy healthcheck failure

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -237,7 +237,7 @@ services:
     depends_on:
       - gateway
     healthcheck:
-      test: ['CMD-SHELL', 'wget -qO /dev/null http://localhost:2019/config/ 2>/dev/null']
+      test: ['CMD-SHELL', 'wget -qO /dev/null http://127.0.0.1:2019/config/ 2>/dev/null']
       interval: 15s
       timeout: 10s
       retries: 5

--- a/gateway/nginx.conf.template
+++ b/gateway/nginx.conf.template
@@ -115,14 +115,15 @@ server {
     # ── Identity Service ──────────────────────────────────────────────────────
     location ~ ^/api/v1/(auth|users|profile|kyc|notifications|saved-items)/ {
         limit_req zone=global burst=20 nodelay;
+        set $upstream_identity http://identity:8001;
 
         # Stricter rate limit on auth endpoints
         location ~ ^/api/v1/auth/(login|register|password-reset) {
             limit_req zone=auth burst=5 nodelay;
+            set $upstream_identity http://identity:8001;
             proxy_pass $upstream_identity;
         }
 
-        set $upstream_identity http://identity:8001;
         proxy_pass $upstream_identity;
     }
 


### PR DESCRIPTION
## Summary

- **Registration broken (500):** The nested nginx location for auth endpoints (`/api/v1/auth/register`, `/login`, `/password-reset`) used `$upstream_identity` before `set` — variable was empty, nginx returned "invalid URL prefix" 500. Moved `set` before the nested block and duplicated inside it (nested locations are separate scopes).

- **Caddy unhealthy for 2+ days:** Healthcheck used `localhost` which resolves to `::1` (IPv6) in Alpine BusyBox, but Caddy's admin API binds to `127.0.0.1` (IPv4 only). 13,325 consecutive failures. Changed to `127.0.0.1`.

## Test plan

- [ ] Verify `POST /api/v1/auth/register` returns 201 (or validation error), not 500
- [ ] Verify Caddy container becomes healthy after deploy
- [ ] Verify other auth endpoints (login, password-reset) work

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes 500 errors on auth registration and makes the Caddy container healthy. Adjusts nginx variable scope and the healthcheck address to ensure correct routing and monitoring.

- **Bug Fixes**
  - nginx: Define `\$upstream_identity` before the auth block and again inside the nested location so it’s in scope; prevents “invalid URL prefix” 500 on `/api/v1/auth/(login|register|password-reset)`.
  - docker-compose: Use `127.0.0.1:2019` in the healthcheck instead of `localhost` to hit Caddy’s IPv4-bound admin API on Alpine.

<sup>Written for commit e3ccc28fe3fcaf3d596d2eed11a4b24386a333c5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

