### PR TITLE
fix(gateway): allow URLs without trailing slash in nginx routes

### DIFF
--- a/gateway/nginx.conf.template
+++ b/gateway/nginx.conf.template
@@ -113,12 +113,12 @@ server {
     }
 
     # ── Identity Service ──────────────────────────────────────────────────────
-    location ~ ^/api/v1/(auth|users|profile|kyc|notifications|saved-items)/ {
+    location ~ ^/api/v1/(auth|users|profile|kyc|notifications|saved-items)(?:/|$) {
         limit_req zone=global burst=20 nodelay;
         set $upstream_identity http://identity:8001;
 
         # Stricter rate limit on auth endpoints
-        location ~ ^/api/v1/auth/(login|register|password-reset) {
+        location ~ ^/api/v1/auth/(login|register|password-reset)(?:/|$) {
             limit_req zone=auth burst=5 nodelay;
             set $upstream_identity http://identity:8001;
             proxy_pass $upstream_identity;
@@ -135,21 +135,21 @@ server {
     }
 
     # ── Guide-Booking Service ─────────────────────────────────────────────────
-    location ~ ^/api/v1/(guides|packages|bookings|attractions|admin)/ {
+    location ~ ^/api/v1/(guides|packages|bookings|attractions|admin)(?:/|$) {
         limit_req zone=global burst=20 nodelay;
         set $upstream_guide http://guide-booking:8003;
         proxy_pass $upstream_guide;
     }
 
     # ── Map Service ───────────────────────────────────────────────────────────
-    location ~ ^/api/v1/(pois|carpool)/ {
+    location ~ ^/api/v1/(pois|carpool)(?:/|$) {
         limit_req zone=global burst=20 nodelay;
         set $upstream_map http://map:8004;
         proxy_pass $upstream_map;
     }
 
     # ── AI Service (SSE support) ──────────────────────────────────────────────
-    location ~ ^/api/v1/(chat|ai|documents)/ {
+    location ~ ^/api/v1/(chat|ai|documents)(?:/|$) {
         limit_req zone=ai burst=10 nodelay;
         proxy_read_timeout 300s;
         proxy_buffering off;


### PR DESCRIPTION
## Summary

- Nginx location patterns required trailing slash before query params
- Frontend calls `/api/v1/attractions?page=1` (no trailing slash) → 404
- Changed all service location regexes from `/` to `(?:/|$)`

## Test plan

- [ ] Deploy to Contabo and restart gateway container
- [ ] Verify `https://api.hena-wadeena.online/api/v1/attractions?page=1` returns data
- [ ] Verify `https://api.hena-wadeena.online/api/v1/guides?page=1` returns data