### PR TITLE
fix(deploy): chown files before git reset to handle root-owned files

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -104,6 +104,9 @@ jobs:
             echo "==> Logging into GHCR"
             echo "$GHCR_TOKEN" | docker login ghcr.io -u "$GHCR_USER" --password-stdin
 
+            echo "==> Fixing file permissions (containers may run as root)"
+            sudo chown -R "$(id -u):$(id -g)" .
+
             echo "==> Resetting working tree"
             git reset --hard
             git clean -fd -e .env


### PR DESCRIPTION
## Summary

The production deployment failed because `git reset --hard` couldn't unlink files owned by root:

```
error: unable to unlink old 'services/identity/src/search/search.controller.ts': Permission denied
error: unable to unlink old 'services/identity/src/unified-search/unified-search.controller.ts': Permission denied
...
fatal: Could not reset index file to revision 'HEAD'.
```

**Root Cause:** Docker containers running as root create files with root ownership. When the deploy script runs as the deploy user, it can't overwrite these files.

**Fix:** Add `sudo chown -R $(id -u):$(id -g) .` before `git reset --hard` to reclaim ownership of all files.

## Test Plan

- [ ] Merge and observe deploy workflow succeeds
- [ ] Verify services come up healthy