### PR TITLE
fix(deploy): retry docker pull on transient network failures

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -137,8 +137,21 @@ jobs:
             fi
 
             echo "==> Pulling images by SHA and tagging as :latest"
+            pull_with_retry() {
+              local image="$1"
+              local attempt=1
+              until docker pull "$image"; do
+                if [ "$attempt" -ge 3 ]; then
+                  echo "ERROR: Failed to pull $image after 3 attempts"
+                  return 1
+                fi
+                echo "Pull failed (attempt $attempt/3), retrying in 10s..."
+                attempt=$((attempt + 1))
+                sleep 10
+              done
+            }
             for svc in identity market guide-booking map ai gateway; do
-              docker pull "ghcr.io/$GHCR_USER/hena-wadeena/$svc:$DEPLOY_SHA"
+              pull_with_retry "ghcr.io/$GHCR_USER/hena-wadeena/$svc:$DEPLOY_SHA"
               docker tag "ghcr.io/$GHCR_USER/hena-wadeena/$svc:$DEPLOY_SHA" \
                 "ghcr.io/$GHCR_USER/hena-wadeena/$svc:latest"
             done


### PR DESCRIPTION
## Root Cause

The deploy failed with a connection reset mid-transfer while pulling the `market` image from GHCR:

```
read tcp [2a02:c207:2315:4042::1]:58226->[2606:50c0:8003::154]:443: read: connection reset by peer
```

The Contabo VPS uses IPv6 to reach GHCR and has intermittent connectivity issues. With `set -euo pipefail`, a single pull failure kills the entire deploy.

## Fix

Added a `pull_with_retry` helper that retries up to 3 times with a 10s backoff before giving up. All 6 service images now go through this helper.

## Test Plan

- [ ] Trigger a deploy to main and verify all images pull successfully