### PR TITLE
ci: remove pnpm version pin from deploy action

### DIFF
--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -29,8 +29,6 @@ jobs:
 
       - name: Install pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 9
 
       - name: Get pnpm store directory
         shell: bash


### PR DESCRIPTION
## Problem

`pnpm/action-setup@v4` fails when `version` is explicitly set while `packageManager` is also defined in `package.json` — it rejects the dual specification.

This caused the Deploy Frontend workflow to fail on every push to `main` since PR #89 merged.

## Fix

Remove `version: 9` from the action config. The action reads the version automatically from `packageManager: pnpm@9.15.0` in `package.json`.