### PR TITLE
feat(f18): guide safety UI — desert trip planning and site status board

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -66,6 +66,7 @@ import GuideBookingPage from './pages/tourism/GuideBookingPage';
 import AccommodationListPage from './pages/tourism/AccommodationListPage';
 import AccommodationDetailsPage from './pages/tourism/AccommodationDetailsPage';
 import AccommodationInquiryPage from './pages/tourism/AccommodationInquiryPage';
+import SiteStatusBoardPage from './pages/tourism/SiteStatusBoardPage';
 
 const AdminLayout = lazy(() => import('@/pages/admin/AdminLayout'));
 const AdminOverview = lazy(() => import('@/pages/admin/AdminOverview'));
@@ -191,6 +192,7 @@ const App = () => (
               path="/tourism/accommodation-inquiry/:id"
               element={<AccommodationInquiryPage />}
             />
+            <Route path="/tourism/sites" element={<SiteStatusBoardPage />} />
 
             <Route path="/logistics" element={<LogisticsPage />} />
             <Route element={<RequireAuth />}>

--- a/apps/web/src/components/desert-trip/DesertTripPanel.tsx
+++ b/apps/web/src/components/desert-trip/DesertTripPanel.tsx
@@ -1,0 +1,97 @@
+import { toast } from 'sonner';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import { Button } from '@/components/ui/button';
+import { Skeleton } from '@/components/ui/skeleton';
+import { useDesertTrip, useCheckInDesertTrip } from '@/hooks/use-desert-trip';
+import { ApiError } from '@/services/api';
+import { pickLocalizedCopy, type AppLanguage } from '@/lib/localization';
+import { RegisterTripForm } from './RegisterTripForm';
+import { TripStatusCard } from './TripStatusCard';
+
+interface DesertTripPanelProps {
+  bookingId: string;
+  isGuide: boolean;
+  language: AppLanguage;
+}
+
+export function DesertTripPanel({ bookingId, isGuide, language }: DesertTripPanelProps) {
+  const { data: trip, isLoading, isError, refetch } = useDesertTrip(bookingId);
+  const checkIn = useCheckInDesertTrip();
+
+  if (isLoading) {
+    return <Skeleton className="mt-4 h-32 w-full rounded-lg" />;
+  }
+
+  if (isError) {
+    return (
+      <Alert variant="destructive" className="mt-4">
+        <AlertDescription>
+          {pickLocalizedCopy(language, {
+            ar: 'تعذّر تحميل بيانات الرحلة.',
+            en: 'Failed to load trip data.',
+          })}
+          <button type="button" onClick={() => void refetch()} className="ms-2 underline">
+            {pickLocalizedCopy(language, { ar: 'إعادة المحاولة', en: 'Retry' })}
+          </button>
+        </AlertDescription>
+      </Alert>
+    );
+  }
+
+  if (!trip) {
+    if (isGuide) {
+      return <RegisterTripForm bookingId={bookingId} language={language} />;
+    }
+    return (
+      <p className="mt-4 text-sm text-muted-foreground">
+        {pickLocalizedCopy(language, {
+          ar: 'لا توجد خطة سلامة بعد',
+          en: 'No safety plan registered yet',
+        })}
+      </p>
+    );
+  }
+
+  const handleCheckIn = () => {
+    checkIn.mutate(bookingId, {
+      onSuccess: () => {
+        toast.success(
+          pickLocalizedCopy(language, {
+            ar: 'تم تسجيل الوصول بنجاح',
+            en: 'Checked in successfully',
+          }),
+        );
+      },
+      onError: (error) => {
+        if (error instanceof ApiError && error.status === 409) {
+          toast.error(
+            pickLocalizedCopy(language, {
+              ar: 'تم تسجيل الوصول مسبقاً',
+              en: 'Already checked in',
+            }),
+          );
+        } else {
+          toast.error(error instanceof Error ? error.message : String(error));
+        }
+      },
+    });
+  };
+
+  return (
+    <div>
+      <TripStatusCard trip={trip} language={language} />
+      {isGuide && trip.status === 'pending' && (
+        <Button
+          onClick={handleCheckIn}
+          disabled={checkIn.isPending}
+          variant="outline"
+          className="mt-3 w-full"
+        >
+          {checkIn.isPending
+            ? pickLocalizedCopy(language, { ar: 'جارٍ التسجيل...', en: 'Checking in...' })
+            : pickLocalizedCopy(language, { ar: 'تسجيل الوصول', en: 'Check In' })}
+        </Button>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/desert-trip/DesertTripPanel.tsx
+++ b/apps/web/src/components/desert-trip/DesertTripPanel.tsx
@@ -80,7 +80,7 @@ export function DesertTripPanel({ bookingId, isGuide, language }: DesertTripPane
   return (
     <div>
       <TripStatusCard trip={trip} language={language} />
-      {isGuide && trip.status === 'pending' && (
+      {isGuide && ['pending', 'overdue', 'alert_sent'].includes(trip.status) && (
         <Button
           onClick={handleCheckIn}
           disabled={checkIn.isPending}

--- a/apps/web/src/components/desert-trip/RegisterTripForm.tsx
+++ b/apps/web/src/components/desert-trip/RegisterTripForm.tsx
@@ -1,0 +1,154 @@
+import { useState } from 'react';
+import { CircleHelp } from 'lucide-react';
+import { toast } from 'sonner';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
+import { useRegisterDesertTrip } from '@/hooks/use-desert-trip';
+import { pickLocalizedCopy, type AppLanguage } from '@/lib/localization';
+import { ApiError } from '@/services/api';
+import type { RegisterDesertTripRequest } from '@/services/api';
+
+interface RegisterTripFormProps {
+  bookingId: string;
+  language: AppLanguage;
+}
+
+export function RegisterTripForm({ bookingId, language }: RegisterTripFormProps) {
+  const [form, setForm] = useState({
+    destinationName: '',
+    emergencyContact: '',
+    expectedArrivalAt: '',
+    rangerStationName: '',
+  });
+
+  const mutation = useRegisterDesertTrip();
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+
+    const body: RegisterDesertTripRequest = {
+      destinationName: form.destinationName.trim(),
+      emergencyContact: form.emergencyContact.trim(),
+      expectedArrivalAt: new Date(form.expectedArrivalAt).toISOString(),
+      ...(form.rangerStationName.trim()
+        ? { rangerStationName: form.rangerStationName.trim() }
+        : {}),
+    };
+
+    mutation.mutate(
+      { bookingId, body },
+      {
+        onSuccess: () => {
+          toast.success(
+            pickLocalizedCopy(language, { ar: 'تم تسجيل خطة الرحلة', en: 'Trip plan registered' }),
+          );
+        },
+        onError: (error) => {
+          if (error instanceof ApiError && error.status === 409) {
+            toast.error(
+              pickLocalizedCopy(language, {
+                ar: 'خطة الرحلة موجودة بالفعل',
+                en: 'Trip plan already exists',
+              }),
+            );
+          } else {
+            toast.error(error instanceof Error ? error.message : String(error));
+          }
+        },
+      },
+    );
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="mt-4 space-y-4 rounded-lg border bg-muted/20 p-4">
+      <p className="text-sm font-semibold">
+        {pickLocalizedCopy(language, {
+          ar: 'تسجيل خطة الرحلة الصحراوية',
+          en: 'Register Desert Trip Plan',
+        })}
+      </p>
+
+      <div className="space-y-2">
+        <Label htmlFor={`dest-${bookingId}`}>
+          {pickLocalizedCopy(language, { ar: 'اسم الوجهة *', en: 'Destination *' })}
+        </Label>
+        <Input
+          id={`dest-${bookingId}`}
+          value={form.destinationName}
+          onChange={(e) => setForm((prev) => ({ ...prev, destinationName: e.target.value }))}
+          required
+        />
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor={`ec-${bookingId}`}>
+          {pickLocalizedCopy(language, { ar: 'جهة الطوارئ *', en: 'Emergency Contact *' })}
+        </Label>
+        <Input
+          id={`ec-${bookingId}`}
+          value={form.emergencyContact}
+          onChange={(e) => setForm((prev) => ({ ...prev, emergencyContact: e.target.value }))}
+          required
+        />
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor={`arrival-${bookingId}`}>
+          {pickLocalizedCopy(language, { ar: 'وقت الوصول المتوقع *', en: 'Expected Arrival *' })}
+        </Label>
+        <Input
+          id={`arrival-${bookingId}`}
+          type="datetime-local"
+          value={form.expectedArrivalAt}
+          onChange={(e) => setForm((prev) => ({ ...prev, expectedArrivalAt: e.target.value }))}
+          required
+        />
+      </div>
+
+      <div className="space-y-2">
+        <div className="flex items-center gap-1.5">
+          <Label htmlFor={`ranger-${bookingId}`}>
+            {pickLocalizedCopy(language, {
+              ar: 'أقرب نقطة حراسة',
+              en: 'Nearest Ranger Post',
+            })}
+          </Label>
+          <Tooltip delayDuration={0}>
+            <TooltipTrigger type="button" className="text-muted-foreground hover:text-foreground">
+              <CircleHelp className="h-3.5 w-3.5" />
+            </TooltipTrigger>
+            <TooltipContent className="max-w-60 text-center">
+              {pickLocalizedCopy(language, {
+                ar: 'نقاط الحراسة هي مراكز حراس المحميات الطبيعية المنتشرة في الصحراء. تُستخدم للتواصل معهم في حالات الطوارئ إذا تأخّر المرشد عن موعد الوصول.',
+                en: 'Ranger posts are staffed desert protectorate outposts. If the guide misses their expected arrival, the nearest post can dispatch a patrol.',
+              })}
+            </TooltipContent>
+          </Tooltip>
+        </div>
+        <Input
+          id={`ranger-${bookingId}`}
+          value={form.rangerStationName}
+          onChange={(e) => setForm((prev) => ({ ...prev, rangerStationName: e.target.value }))}
+          placeholder={pickLocalizedCopy(language, {
+            ar: 'مثال: نقطة حراسة الخارجة',
+            en: 'e.g. Al-Kharga Guard Post',
+          })}
+        />
+        <p className="text-xs text-muted-foreground">
+          {pickLocalizedCopy(language, {
+            ar: 'اختياري — اسم أقرب نقطة حراسة على مسار الرحلة',
+            en: 'Optional — name of the nearest ranger post along your route',
+          })}
+        </p>
+      </div>
+
+      <Button type="submit" disabled={mutation.isPending} className="w-full">
+        {mutation.isPending
+          ? pickLocalizedCopy(language, { ar: 'جارٍ التسجيل...', en: 'Registering...' })
+          : pickLocalizedCopy(language, { ar: 'تسجيل خطة الرحلة', en: 'Register Trip Plan' })}
+      </Button>
+    </form>
+  );
+}

--- a/apps/web/src/components/desert-trip/TripStatusCard.tsx
+++ b/apps/web/src/components/desert-trip/TripStatusCard.tsx
@@ -1,0 +1,107 @@
+import { Badge } from '@/components/ui/badge';
+import { formatDateTimeShort } from '@/lib/dates';
+import { pickLocalizedCopy, type AppLanguage } from '@/lib/localization';
+import type { DesertTrip } from '@/services/api';
+
+const STATUS_BADGE_CLASS: Record<DesertTrip['status'], string> = {
+  pending: 'bg-muted text-muted-foreground',
+  checked_in: 'bg-green-500 text-white',
+  overdue: 'bg-amber-500 text-white',
+  alert_sent: 'bg-red-500 text-white',
+  resolved: 'bg-muted text-muted-foreground',
+};
+
+const STATUS_LABELS: Record<DesertTrip['status'], { ar: string; en: string }> = {
+  pending: { ar: 'قيد الانتظار', en: 'Pending' },
+  checked_in: { ar: 'تم تسجيل الوصول', en: 'Checked In' },
+  overdue: { ar: 'متأخر', en: 'Overdue' },
+  alert_sent: { ar: 'تم إرسال التنبيه', en: 'Alert Sent' },
+  resolved: { ar: 'تم الحل', en: 'Resolved' },
+};
+
+function statusLabel(status: DesertTrip['status'], language: AppLanguage): string {
+  return pickLocalizedCopy(language, STATUS_LABELS[status]);
+}
+
+interface TripStatusCardProps {
+  trip: DesertTrip;
+  language: AppLanguage;
+}
+
+export function TripStatusCard({ trip, language }: TripStatusCardProps) {
+  return (
+    <div className="mt-4 rounded-lg border bg-muted/20 p-4 space-y-3">
+      <div className="flex items-center justify-between">
+        <span className="text-sm font-medium">
+          {pickLocalizedCopy(language, { ar: 'خطة رحلة صحراوية', en: 'Desert Trip Plan' })}
+        </span>
+        <Badge className={STATUS_BADGE_CLASS[trip.status]}>
+          {statusLabel(trip.status, language)}
+        </Badge>
+      </div>
+
+      <div className="grid grid-cols-2 gap-3 text-sm">
+        <div>
+          <p className="text-muted-foreground text-xs">
+            {pickLocalizedCopy(language, { ar: 'الوجهة', en: 'Destination' })}
+          </p>
+          <p className="font-medium">{trip.destinationName}</p>
+        </div>
+        <div>
+          <p className="text-muted-foreground text-xs">
+            {pickLocalizedCopy(language, { ar: 'وقت الوصول المتوقع', en: 'Expected Arrival' })}
+          </p>
+          <p className="font-medium">{formatDateTimeShort(trip.expectedArrivalAt, language)}</p>
+        </div>
+        <div>
+          <p className="text-muted-foreground text-xs">
+            {pickLocalizedCopy(language, { ar: 'جهة الطوارئ', en: 'Emergency Contact' })}
+          </p>
+          <p className="font-medium">{trip.emergencyContact}</p>
+        </div>
+        {trip.rangerStationName && (
+          <div className="col-span-2">
+            <p className="text-muted-foreground text-xs">
+              {pickLocalizedCopy(language, { ar: 'نقطة الحراسة', en: 'Ranger Post' })}
+            </p>
+            <p className="font-medium">{trip.rangerStationName}</p>
+          </div>
+        )}
+        {trip.checkedInAt && (
+          <div>
+            <p className="text-muted-foreground text-xs">
+              {pickLocalizedCopy(language, { ar: 'وقت تسجيل الوصول', en: 'Checked In At' })}
+            </p>
+            <p className="font-medium text-green-600">
+              {formatDateTimeShort(trip.checkedInAt, language)}
+            </p>
+          </div>
+        )}
+        {trip.alertTriggeredAt && (
+          <div className="col-span-2">
+            <p className="text-xs text-red-500">
+              {pickLocalizedCopy(language, { ar: 'وقت إرسال التنبيه', en: 'Alert Triggered At' })}
+            </p>
+            <p className="font-medium text-red-600">
+              {formatDateTimeShort(trip.alertTriggeredAt, language)}
+            </p>
+          </div>
+        )}
+      </div>
+
+      {(trip.status === 'overdue' || trip.status === 'alert_sent') && (
+        <p className="rounded bg-amber-50 px-3 py-2 text-xs text-amber-700 dark:bg-amber-950 dark:text-amber-300">
+          {trip.status === 'alert_sent'
+            ? pickLocalizedCopy(language, {
+                ar: 'تم إخطار السلطات. يرجى التحقق من سلامة المرشد.',
+                en: 'Authorities have been notified. Please verify guide safety.',
+              })
+            : pickLocalizedCopy(language, {
+                ar: 'تجاوز وقت الوصول المتوقع.',
+                en: 'Expected arrival time has passed.',
+              })}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/hooks/use-desert-trip.spec.ts
+++ b/apps/web/src/hooks/use-desert-trip.spec.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// All variables referenced directly in vi.mock factory return values must use
+// vi.hoisted() so they are available when Vitest evaluates the factories
+// (before module imports are resolved).
+
+const mockInvalidate = vi.hoisted(() => vi.fn());
+const mockGetByBooking = vi.hoisted(() => vi.fn());
+const mockRegister = vi.hoisted(() => vi.fn());
+const mockCheckIn = vi.hoisted(() => vi.fn());
+
+// ApiError must also be hoisted: the hook uses `instanceof ApiError`, and the
+// same class must be shared between the mock factory and the test assertions.
+const mockUseAuth = vi.hoisted(() => vi.fn().mockReturnValue({ isAuthenticated: true }));
+
+const MockApiError = vi.hoisted(() => {
+  class ApiError extends Error {
+    status: number;
+    constructor(status: number, message: string) {
+      super(message);
+      this.name = 'ApiError';
+      this.status = status;
+    }
+  }
+  return ApiError;
+});
+
+vi.mock('@/services/api', () => ({
+  ApiError: MockApiError,
+  desertTripsAPI: {
+    getByBooking: mockGetByBooking,
+    register: mockRegister,
+    checkIn: mockCheckIn,
+  },
+}));
+
+vi.mock('@/lib/query-keys', () => ({
+  queryKeys: {
+    desertTrips: {
+      byBooking: (id: string) => ['desert-trips', id] as const,
+    },
+  },
+}));
+
+vi.mock('@/hooks/use-auth', () => ({
+  useAuth: mockUseAuth,
+}));
+
+// capturedQueryOptions / capturedMutationOptions are only assigned inside
+// mockImplementation callbacks, never at factory evaluation time, so regular
+// let declarations are safe here (no TDZ risk during factory setup).
+let capturedQueryOptions: Record<string, unknown> = {};
+let capturedMutationOptions: Record<string, unknown> = {};
+
+vi.mock('@tanstack/react-query', () => ({
+  useQuery: vi.fn().mockImplementation((options: Record<string, unknown>) => {
+    capturedQueryOptions = options;
+    return { data: undefined, isLoading: false };
+  }),
+  useMutation: vi.fn().mockImplementation((options: Record<string, unknown>) => {
+    capturedMutationOptions = options;
+    return { mutate: vi.fn() };
+  }),
+  useQueryClient: vi.fn().mockReturnValue({ invalidateQueries: mockInvalidate }),
+}));
+
+import { useDesertTrip, useRegisterDesertTrip, useCheckInDesertTrip } from './use-desert-trip';
+
+describe('useDesertTrip', () => {
+  it('is disabled when bookingId is undefined', () => {
+    useDesertTrip(undefined);
+    expect(capturedQueryOptions.enabled).toBe(false);
+  });
+
+  it('is disabled when not authenticated', () => {
+    mockUseAuth.mockReturnValueOnce({ isAuthenticated: false });
+    useDesertTrip('b1');
+    expect(capturedQueryOptions.enabled).toBe(false);
+  });
+
+  it('returns null when API throws 404', async () => {
+    mockGetByBooking.mockRejectedValueOnce(new MockApiError(404, 'Not Found'));
+    useDesertTrip('b1');
+    const result = await (capturedQueryOptions.queryFn as () => Promise<unknown>)();
+    expect(result).toBeNull();
+  });
+
+  it('returns trip data on success', async () => {
+    const trip = { id: 't1', status: 'pending' };
+    mockGetByBooking.mockResolvedValueOnce(trip);
+    useDesertTrip('b1');
+    const result = await (capturedQueryOptions.queryFn as () => Promise<unknown>)();
+    expect(result).toEqual(trip);
+  });
+
+  it('rethrows non-404 errors', async () => {
+    mockGetByBooking.mockRejectedValueOnce(new MockApiError(500, 'Server Error'));
+    useDesertTrip('b1');
+    await expect((capturedQueryOptions.queryFn as () => Promise<unknown>)()).rejects.toMatchObject({
+      status: 500,
+    });
+  });
+});
+
+describe('useRegisterDesertTrip', () => {
+  beforeEach(() => {
+    mockInvalidate.mockClear();
+  });
+
+  it('calls desertTripsAPI.register with correct args', async () => {
+    mockRegister.mockResolvedValueOnce({ id: 't1' });
+    useRegisterDesertTrip();
+    const vars = {
+      bookingId: 'b1',
+      body: {
+        destinationName: 'Wadi',
+        emergencyContact: '01012345678',
+        expectedArrivalAt: '2026-05-01T10:00:00Z',
+      },
+    };
+    await (capturedMutationOptions.mutationFn as (v: typeof vars) => Promise<unknown>)(vars);
+    expect(mockRegister).toHaveBeenCalledWith('b1', vars.body);
+  });
+
+  it('invalidates desert-trip query key on success', async () => {
+    useRegisterDesertTrip();
+    const vars = { bookingId: 'b1', body: {} };
+    await (capturedMutationOptions.onSuccess as (data: unknown, v: typeof vars) => Promise<void>)(
+      {},
+      vars,
+    );
+    expect(mockInvalidate).toHaveBeenCalledWith({ queryKey: ['desert-trips', 'b1'] });
+  });
+});
+
+describe('useCheckInDesertTrip', () => {
+  beforeEach(() => {
+    mockInvalidate.mockClear();
+  });
+
+  it('calls desertTripsAPI.checkIn with correct bookingId', async () => {
+    mockCheckIn.mockResolvedValueOnce({ id: 't1' });
+    useCheckInDesertTrip();
+    await (capturedMutationOptions.mutationFn as (id: string) => Promise<unknown>)('b1');
+    expect(mockCheckIn).toHaveBeenCalledWith('b1');
+  });
+
+  it('invalidates desert-trip query key on success', async () => {
+    useCheckInDesertTrip();
+    await (
+      capturedMutationOptions.onSuccess as (data: unknown, bookingId: string) => Promise<void>
+    )({}, 'b1');
+    expect(mockInvalidate).toHaveBeenCalledWith({ queryKey: ['desert-trips', 'b1'] });
+  });
+});

--- a/apps/web/src/hooks/use-desert-trip.spec.ts
+++ b/apps/web/src/hooks/use-desert-trip.spec.ts
@@ -37,7 +37,7 @@ vi.mock('@/services/api', () => ({
 vi.mock('@/lib/query-keys', () => ({
   queryKeys: {
     desertTrips: {
-      byBooking: (id: string) => ['desert-trips', id] as const,
+      byBooking: (id: string) => ['desert-trips', 'booking', id] as const,
     },
   },
 }));
@@ -129,7 +129,7 @@ describe('useRegisterDesertTrip', () => {
       {},
       vars,
     );
-    expect(mockInvalidate).toHaveBeenCalledWith({ queryKey: ['desert-trips', 'b1'] });
+    expect(mockInvalidate).toHaveBeenCalledWith({ queryKey: ['desert-trips', 'booking', 'b1'] });
   });
 });
 
@@ -150,6 +150,6 @@ describe('useCheckInDesertTrip', () => {
     await (
       capturedMutationOptions.onSuccess as (data: unknown, bookingId: string) => Promise<void>
     )({}, 'b1');
-    expect(mockInvalidate).toHaveBeenCalledWith({ queryKey: ['desert-trips', 'b1'] });
+    expect(mockInvalidate).toHaveBeenCalledWith({ queryKey: ['desert-trips', 'booking', 'b1'] });
   });
 });

--- a/apps/web/src/hooks/use-desert-trip.ts
+++ b/apps/web/src/hooks/use-desert-trip.ts
@@ -1,0 +1,46 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { ApiError, desertTripsAPI } from '@/services/api';
+import type { RegisterDesertTripRequest } from '@/services/api';
+import { queryKeys } from '@/lib/query-keys';
+import { useAuth } from '@/hooks/use-auth';
+
+export function useDesertTrip(bookingId: string | undefined) {
+  const { isAuthenticated } = useAuth();
+  return useQuery({
+    queryKey: queryKeys.desertTrips.byBooking(bookingId ?? ''),
+    queryFn: async () => {
+      try {
+        return await desertTripsAPI.getByBooking(bookingId!);
+      } catch (error) {
+        if (error instanceof ApiError && error.status === 404) return null;
+        throw error;
+      }
+    },
+    enabled: isAuthenticated && !!bookingId,
+  });
+}
+
+export function useRegisterDesertTrip() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({ bookingId, body }: { bookingId: string; body: RegisterDesertTripRequest }) =>
+      desertTripsAPI.register(bookingId, body),
+    onSuccess: (_data, { bookingId }) => {
+      void queryClient.invalidateQueries({
+        queryKey: queryKeys.desertTrips.byBooking(bookingId),
+      });
+    },
+  });
+}
+
+export function useCheckInDesertTrip() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (bookingId: string) => desertTripsAPI.checkIn(bookingId),
+    onSuccess: (_data, bookingId) => {
+      void queryClient.invalidateQueries({
+        queryKey: queryKeys.desertTrips.byBooking(bookingId),
+      });
+    },
+  });
+}

--- a/apps/web/src/hooks/use-map.ts
+++ b/apps/web/src/hooks/use-map.ts
@@ -171,3 +171,17 @@ export function useDeclinePassenger() {
     },
   });
 }
+
+export function useStatusBoard(page: number, search = '', status = 'all', limit = 12) {
+  return useQuery({
+    queryKey: queryKeys.map.statusBoard(page, search, status),
+    queryFn: () =>
+      mapAPI.getStatusBoard(
+        page,
+        limit,
+        search || undefined,
+        status === 'all' ? undefined : status,
+      ),
+    staleTime: 5 * 60 * 1000,
+  });
+}

--- a/apps/web/src/lib/query-keys.ts
+++ b/apps/web/src/lib/query-keys.ts
@@ -67,6 +67,8 @@ export const queryKeys = {
     carpool: (filters?: Record<string, unknown>) => ['map', 'carpool', filters] as const,
     ride: (id: string) => ['map', 'carpool', id] as const,
     myRides: () => ['map', 'my-rides'] as const,
+    statusBoard: (page: number, search?: string, status?: string) =>
+      ['map', 'status-board', page, search ?? '', status ?? ''] as const,
   },
   search: {
     results: (query: string, filters?: Record<string, unknown>) =>
@@ -133,5 +135,8 @@ export const queryKeys = {
     myPosts: () => ['jobs', 'my-posts'] as const,
     reviews: () => ['jobs', 'reviews'] as const,
     userReviews: (userId: string) => ['jobs', 'reviews', userId] as const,
+  },
+  desertTrips: {
+    byBooking: (bookingId: string) => ['desert-trips', 'booking', bookingId] as const,
   },
 };

--- a/apps/web/src/pages/__tests__/account-pages-localization.spec.tsx
+++ b/apps/web/src/pages/__tests__/account-pages-localization.spec.tsx
@@ -127,6 +127,10 @@ vi.mock('@/hooks/use-reviews', () => ({
   useCreateReview: () => ({ mutate: vi.fn(), isPending: false }),
 }));
 
+vi.mock('@/components/desert-trip/DesertTripPanel', () => ({
+  DesertTripPanel: () => null,
+}));
+
 vi.mock('sonner', () => ({
   toast: {
     success: vi.fn(),

--- a/apps/web/src/pages/profile/BookingsPage.tsx
+++ b/apps/web/src/pages/profile/BookingsPage.tsx
@@ -40,6 +40,7 @@ import {
   useCompleteBooking,
 } from '@/hooks/use-bookings';
 import { useMyReviewedBookingIds, useCreateReview } from '@/hooks/use-reviews';
+import { DesertTripPanel } from '@/components/desert-trip/DesertTripPanel';
 import { getBookingStatusLabels } from '@/lib/booking-status';
 import { piastresToEgp } from '@/lib/format';
 import { UserRole } from '@hena-wadeena/types';
@@ -80,7 +81,10 @@ function formatPeopleCount(count: number, language: AppLanguage): string {
     return `${count} ${count === 1 ? 'person' : 'people'}`;
   }
 
-  return `${count} أشخاص`;
+  if (count === 1) return 'شخص واحد';
+  if (count === 2) return 'شخصان';
+  if (count <= 10) return `${count} أشخاص`;
+  return `${count} شخصاً`;
 }
 
 function getActionDialogCopy(
@@ -466,19 +470,26 @@ const BookingsPage = () => {
                 <Card className="rounded-2xl">
                   <CardContent className="space-y-4 p-14 text-center">
                     <p className="text-lg text-muted-foreground">
-                      {pickLocalizedCopy(appLanguage, {
-                        ar: 'لا توجد حجوزات حتى الآن. ابدأ باستكشاف المرشدين السياحيين!',
-                        en: 'No bookings yet. Start exploring tour guides!',
-                      })}
+                      {isGuide
+                        ? pickLocalizedCopy(appLanguage, {
+                            ar: 'لا توجد حجوزات حتى الآن. ستظهر هنا بمجرد أن يحجز أحد معك.',
+                            en: 'No bookings yet. They will appear here once someone books with you.',
+                          })
+                        : pickLocalizedCopy(appLanguage, {
+                            ar: 'لا توجد حجوزات حتى الآن. ابدأ باستكشاف المرشدين السياحيين!',
+                            en: 'No bookings yet. Start exploring tour guides!',
+                          })}
                     </p>
-                    <Link to="/guides">
-                      <Button variant="outline">
-                        {pickLocalizedCopy(appLanguage, {
-                          ar: 'تصفّح المرشدين',
-                          en: 'Browse guides',
-                        })}
-                      </Button>
-                    </Link>
+                    {!isGuide && (
+                      <Link to="/guides">
+                        <Button variant="outline">
+                          {pickLocalizedCopy(appLanguage, {
+                            ar: 'تصفّح المرشدين',
+                            en: 'Browse guides',
+                          })}
+                        </Button>
+                      </Link>
+                    )}
                   </CardContent>
                 </Card>
               </SR>
@@ -552,6 +563,13 @@ const BookingsPage = () => {
                             </p>
                           )}
                           {renderActions(booking)}
+                          {['pending', 'confirmed', 'in_progress'].includes(booking.status) && (
+                            <DesertTripPanel
+                              bookingId={booking.id}
+                              isGuide={isGuide}
+                              language={appLanguage}
+                            />
+                          )}
                         </CardContent>
                       </Card>
                     </SR>
@@ -607,7 +625,7 @@ const BookingsPage = () => {
               className="mt-2"
             />
           </div>
-          <DialogFooter className="gap-2 sm:gap-0">
+          <DialogFooter className="gap-2">
             <Button
               variant="outline"
               onClick={() => {
@@ -653,7 +671,7 @@ const BookingsPage = () => {
                 : null}
             </DialogDescription>
           </DialogHeader>
-          <DialogFooter className="gap-2 sm:gap-0">
+          <DialogFooter className="gap-2">
             <Button variant="outline" onClick={() => setActionTarget(null)}>
               {pickLocalizedCopy(appLanguage, {
                 ar: 'تراجع',
@@ -785,7 +803,7 @@ const BookingsPage = () => {
             )}
           </div>
 
-          <DialogFooter className="gap-2 sm:gap-0">
+          <DialogFooter className="gap-2">
             <Button
               variant="outline"
               onClick={() => {

--- a/apps/web/src/pages/tourism/SiteStatusBoardPage.tsx
+++ b/apps/web/src/pages/tourism/SiteStatusBoardPage.tsx
@@ -1,5 +1,4 @@
 import { useState } from 'react';
-import { useQuery } from '@tanstack/react-query';
 import { Layout } from '@/components/layout/Layout';
 import { PageHero } from '@/components/layout/PageHero';
 import { Search, MapPin, AlertCircle, ArrowRight } from 'lucide-react';
@@ -9,8 +8,7 @@ import { Card, CardContent } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Skeleton } from '@/components/ui/skeleton';
-import { mapAPI } from '@/services/api';
-import { queryKeys } from '@/lib/query-keys';
+import { useStatusBoard } from '@/hooks/use-map';
 import { useAuth } from '@/hooks/use-auth';
 import { pickLocalizedCopy } from '@/lib/localization';
 import { useDebouncedCallback } from '@/hooks/use-debounce';
@@ -28,10 +26,7 @@ function SiteStatusBoardPage() {
   const [search, setSearch] = useState('');
   const [statusFilter, setStatusFilter] = useState<string | undefined>();
 
-  const { data, isLoading, isError } = useQuery({
-    queryKey: queryKeys.map.statusBoard(page, search, statusFilter),
-    queryFn: () => mapAPI.getStatusBoard(page, 12, search || undefined, statusFilter),
-  });
+  const { data, isLoading, isError } = useStatusBoard(page, search, statusFilter ?? 'all');
 
   const handleSearch = useDebouncedCallback((value: string) => {
     setSearch(value);
@@ -72,7 +67,7 @@ function SiteStatusBoardPage() {
       </PageHero>
 
       <div className="container mx-auto px-4 py-8">
-        <div className="mb-6">
+        <div className="mb-6 grid gap-3 md:grid-cols-[1fr_auto]">
           <div className="relative">
             <Search className="absolute start-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
             <Input
@@ -81,6 +76,26 @@ function SiteStatusBoardPage() {
               onChange={(e) => handleSearch(e.target.value)}
             />
           </div>
+          <select
+            aria-label={pickLocalizedCopy(language, { ar: 'تصفية الحالة', en: 'Filter status' })}
+            value={statusFilter ?? ''}
+            onChange={(e) => {
+              setStatusFilter(e.target.value || undefined);
+              setPage(1);
+            }}
+            className="h-10 rounded-md border bg-background px-3 text-sm"
+          >
+            <option value="">
+              {pickLocalizedCopy(language, { ar: 'كل الحالات', en: 'All statuses' })}
+            </option>
+            <option value="open">{pickLocalizedCopy(language, { ar: 'مفتوح', en: 'Open' })}</option>
+            <option value="limited">
+              {pickLocalizedCopy(language, { ar: 'جزئي', en: 'Limited' })}
+            </option>
+            <option value="closed">
+              {pickLocalizedCopy(language, { ar: 'مغلق', en: 'Closed' })}
+            </option>
+          </select>
         </div>
 
         {isLoading && (

--- a/apps/web/src/pages/tourism/SiteStatusBoardPage.tsx
+++ b/apps/web/src/pages/tourism/SiteStatusBoardPage.tsx
@@ -1,0 +1,168 @@
+import { useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { Layout } from '@/components/layout/Layout';
+import { PageHero } from '@/components/layout/PageHero';
+import { Search, MapPin, AlertCircle, ArrowRight } from 'lucide-react';
+import { useNavigate } from 'react-router';
+import { Input } from '@/components/ui/input';
+import { Card, CardContent } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Skeleton } from '@/components/ui/skeleton';
+import { mapAPI } from '@/services/api';
+import { queryKeys } from '@/lib/query-keys';
+import { useAuth } from '@/hooks/use-auth';
+import { pickLocalizedCopy } from '@/lib/localization';
+import { useDebouncedCallback } from '@/hooks/use-debounce';
+
+const STATUS_COLORS: Record<string, string> = {
+  open: 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200',
+  closed: 'bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200',
+  limited: 'bg-amber-100 text-amber-800 dark:bg-amber-900 dark:text-amber-200',
+};
+
+function SiteStatusBoardPage() {
+  const navigate = useNavigate();
+  const { language } = useAuth();
+  const [page, setPage] = useState(1);
+  const [search, setSearch] = useState('');
+  const [statusFilter, setStatusFilter] = useState<string | undefined>();
+
+  const { data, isLoading, isError } = useQuery({
+    queryKey: queryKeys.map.statusBoard(page, search, statusFilter),
+    queryFn: () => mapAPI.getStatusBoard(page, 12, search || undefined, statusFilter),
+  });
+
+  const handleSearch = useDebouncedCallback((value: string) => {
+    setSearch(value);
+    setPage(1);
+  }, 300);
+
+  const t = {
+    title: pickLocalizedCopy(language, { ar: 'حالة المواقع', en: 'Site Status' }),
+    description: pickLocalizedCopy(language, {
+      ar: 'معرفة حالة المواقع السياحية والخدمية',
+      en: 'Check the status of tourist and service sites',
+    }),
+    searchPlaceholder: pickLocalizedCopy(language, {
+      ar: 'البحث عن موقع...',
+      en: 'Search sites...',
+    }),
+    noResults: pickLocalizedCopy(language, { ar: 'لا توجد نتائج', en: 'No results found' }),
+    error: pickLocalizedCopy(language, { ar: 'حدث خطأ', en: 'An error occurred' }),
+    previous: pickLocalizedCopy(language, { ar: 'السابق', en: 'Previous' }),
+    next: pickLocalizedCopy(language, { ar: 'التالي', en: 'Next' }),
+  };
+
+  return (
+    <Layout title={t.title}>
+      <PageHero image="/images/seed/desert-landscape.jpg" alt={t.title}>
+        <div className="mb-6 flex justify-center">
+          <Button
+            variant="ghost"
+            onClick={() => void navigate('/tourism')}
+            className="text-card hover:bg-card/10 hover:text-card"
+          >
+            <ArrowRight className="h-4 w-4" />
+            {pickLocalizedCopy(language, { ar: 'العودة إلى السياحة', en: 'Back to Tourism' })}
+          </Button>
+        </div>
+        <h1 className="mb-4 text-center text-4xl font-bold tracking-tight text-card">{t.title}</h1>
+        <p className="text-center text-lg text-card/80">{t.description}</p>
+      </PageHero>
+
+      <div className="container mx-auto px-4 py-8">
+        <div className="mb-6">
+          <div className="relative">
+            <Search className="absolute start-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+            <Input
+              placeholder={t.searchPlaceholder}
+              className="ps-9"
+              onChange={(e) => handleSearch(e.target.value)}
+            />
+          </div>
+        </div>
+
+        {isLoading && (
+          <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+            {Array.from({ length: 6 }).map((_, i) => (
+              <Card key={i}>
+                <CardContent className="p-4">
+                  <Skeleton className="mb-2 h-5 w-3/4" />
+                  <Skeleton className="h-4 w-1/2" />
+                </CardContent>
+              </Card>
+            ))}
+          </div>
+        )}
+
+        {isError && (
+          <div className="flex flex-col items-center justify-center py-12">
+            <AlertCircle className="mb-2 h-8 w-8 text-destructive" />
+            <p className="text-muted-foreground">{t.error}</p>
+          </div>
+        )}
+
+        {data && data.data.length === 0 && (
+          <div className="flex flex-col items-center justify-center py-12">
+            <MapPin className="mb-2 h-8 w-8 text-muted-foreground" />
+            <p className="text-muted-foreground">{t.noResults}</p>
+          </div>
+        )}
+
+        {data && data.data.length > 0 && (
+          <>
+            <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+              {data.data.map((site) => (
+                <Card key={site.id}>
+                  <CardContent className="p-4">
+                    <div className="mb-2 flex items-start justify-between gap-2">
+                      <h3 className="font-semibold">
+                        {language === 'ar' ? site.nameAr : site.nameEn || site.nameAr}
+                      </h3>
+                      {site.status && (
+                        <Badge
+                          variant="secondary"
+                          className={STATUS_COLORS[site.status] || 'bg-muted'}
+                        >
+                          {site.status}
+                        </Badge>
+                      )}
+                    </div>
+                    <p className="text-sm text-muted-foreground">{site.category}</p>
+                    {(site.statusNoteAr || site.statusNoteEn) && (
+                      <p className="mt-2 text-xs text-muted-foreground">
+                        {language === 'ar'
+                          ? site.statusNoteAr
+                          : site.statusNoteEn || site.statusNoteAr}
+                      </p>
+                    )}
+                  </CardContent>
+                </Card>
+              ))}
+            </div>
+
+            <div className="mt-6 flex justify-center gap-2">
+              <Button
+                variant="outline"
+                onClick={() => setPage((p) => Math.max(1, p - 1))}
+                disabled={page === 1}
+              >
+                {t.previous}
+              </Button>
+              <Button
+                variant="outline"
+                onClick={() => setPage((p) => p + 1)}
+                disabled={!data.hasMore}
+              >
+                {t.next}
+              </Button>
+            </div>
+          </>
+        )}
+      </div>
+    </Layout>
+  );
+}
+
+export default SiteStatusBoardPage;

--- a/apps/web/src/services/api.ts
+++ b/apps/web/src/services/api.ts
@@ -1442,6 +1442,19 @@ export interface Poi {
   deletedAt: string | null;
 }
 
+export interface PoiWithStatus {
+  id: string;
+  nameAr: string;
+  nameEn: string | null;
+  category: string;
+  location: { x: number; y: number }; // PostGIS point: x=lng, y=lat
+  status: string | null;
+  statusNoteAr: string | null;
+  statusNoteEn: string | null;
+  validUntil: string | null;
+  statusUpdatedAt: string | null;
+}
+
 // ── Carpool ────────────────────────────────────────────────────────────────
 
 export type CarpoolRideStatus = 'open' | 'full' | 'departed' | 'completed' | 'cancelled';
@@ -1567,6 +1580,15 @@ export const mapAPI = {
     apiFetchWithRefresh<{ asDriver: CarpoolRide[]; asPassenger: CarpoolPassenger[] }>(
       '/carpool/my',
     ),
+
+  getStatusBoard: (page = 1, limit = 12, search?: string, status?: string) => {
+    const params = new URLSearchParams({ page: String(page), limit: String(limit) });
+    if (search) params.set('search', search);
+    if (status) params.set('status', status);
+    return apiFetch<PaginatedResponse<PoiWithStatus>>(
+      `/map/sites/status-board?${params.toString()}`,
+    );
+  },
 };
 
 // ── Admin ───────────────────────────────────────────────────────────────────
@@ -2334,4 +2356,46 @@ export const jobsAPI = {
     apiFetchWithRefresh<PaginatedResponse<JobApplication>>('/jobs/my-applications'),
 
   getMyPosts: () => apiFetchWithRefresh<PaginatedResponse<JobPost>>('/jobs/my-posts'),
+};
+
+// ── Desert Trips (Guide Safety) ─────────────────────────────────────────────
+
+export type DesertTripStatus = 'pending' | 'checked_in' | 'overdue' | 'alert_sent' | 'resolved';
+
+export interface DesertTrip {
+  id: string;
+  bookingId: string;
+  guideId: string;
+  destinationName: string;
+  emergencyContact: string;
+  expectedArrivalAt: string;
+  rangerStationName: string | null;
+  status: DesertTripStatus;
+  checkedInAt: string | null;
+  alertTriggeredAt: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface RegisterDesertTripRequest {
+  destinationName: string;
+  emergencyContact: string;
+  expectedArrivalAt: string;
+  rangerStationName?: string;
+}
+
+export const desertTripsAPI = {
+  getByBooking: (bookingId: string) =>
+    apiFetchWithRefresh<DesertTrip>(`/bookings/${bookingId}/desert-trip`),
+
+  register: (bookingId: string, body: RegisterDesertTripRequest) =>
+    apiFetchWithRefresh<DesertTrip>(`/bookings/${bookingId}/desert-trip`, {
+      method: 'POST',
+      body: JSON.stringify(body),
+    }),
+
+  checkIn: (bookingId: string) =>
+    apiFetchWithRefresh<DesertTrip>(`/bookings/${bookingId}/desert-trip/check-in`, {
+      method: 'POST',
+    }),
 };

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -11,6 +11,8 @@ export default defineConfig({
     include: ['src/**/*.{test,spec}.{ts,tsx}'],
   },
   resolve: {
-    alias: { '@': path.resolve(__dirname, './src') },
+    alias: {
+      '@': path.resolve(__dirname, './src'),
+    },
   },
 });

--- a/services/guide-booking/drizzle/20260412171146_rename_ranger_station_id_to_name.sql
+++ b/services/guide-booking/drizzle/20260412171146_rename_ranger_station_id_to_name.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "guide_booking"."desert_trips" RENAME COLUMN "ranger_station_id" TO "ranger_station_name";--> statement-breakpoint
+ALTER TABLE "guide_booking"."desert_trips" ALTER COLUMN "ranger_station_name" SET DATA TYPE text;

--- a/services/guide-booking/drizzle/meta/_journal.json
+++ b/services/guide-booking/drizzle/meta/_journal.json
@@ -99,6 +99,13 @@
       "when": 1775628293049,
       "tag": "20260408060453_spooky_runaways",
       "breakpoints": true
+    },
+    {
+      "idx": 14,
+      "version": "7",
+      "when": 1776171106000,
+      "tag": "20260412171146_rename_ranger_station_id_to_name",
+      "breakpoints": true
     }
   ]
 }

--- a/services/guide-booking/src/db/schema/desert-trips.ts
+++ b/services/guide-booking/src/db/schema/desert-trips.ts
@@ -16,7 +16,7 @@ export const desertTrips = guideBookingSchema.table(
     expectedArrivalAt: timestamp('expected_arrival_at', { withTimezone: true }).notNull(),
     destinationName: text('destination_name').notNull(),
     emergencyContact: text('emergency_contact').notNull(),
-    rangerStationId: uuid('ranger_station_id'), // plain UUID; no cross-schema FK
+    rangerStationName: text('ranger_station_name'), // free-text name; no cross-schema FK
     checkedInAt: timestamp('checked_in_at', { withTimezone: true }),
     alertTriggeredAt: timestamp('alert_triggered_at', { withTimezone: true }),
     gpsBreadcrumbs: jsonb('gps_breadcrumbs')

--- a/services/guide-booking/src/desert-trips/desert-trips.service.spec.ts
+++ b/services/guide-booking/src/desert-trips/desert-trips.service.spec.ts
@@ -32,7 +32,7 @@ const mockTrip = {
   expectedArrivalAt: new Date('2026-04-10T14:00:00Z'),
   destinationName: 'White Desert',
   emergencyContact: '+201012345678',
-  rangerStationId: null,
+  rangerStationName: null,
   checkedInAt: null,
   alertTriggeredAt: null,
   gpsBreadcrumbs: [],

--- a/services/guide-booking/src/desert-trips/desert-trips.service.ts
+++ b/services/guide-booking/src/desert-trips/desert-trips.service.ts
@@ -67,7 +67,7 @@ export class DesertTripsService {
         expectedArrivalAt: new Date(dto.expectedArrivalAt),
         destinationName: dto.destinationName,
         emergencyContact: dto.emergencyContact,
-        rangerStationId: dto.rangerStationId ?? null,
+        rangerStationName: dto.rangerStationName ?? null,
       })
       .onConflictDoNothing({ target: desertTrips.bookingId })
       .returning();

--- a/services/guide-booking/src/desert-trips/dto/create-desert-trip.dto.ts
+++ b/services/guide-booking/src/desert-trips/dto/create-desert-trip.dto.ts
@@ -5,7 +5,7 @@ export const createDesertTripSchema = z.object({
   expectedArrivalAt: z.iso.datetime({ message: 'Must be an ISO 8601 datetime' }),
   destinationName: z.string().min(1),
   emergencyContact: z.string().min(1),
-  rangerStationId: z.uuid().optional(),
+  rangerStationName: z.string().min(1).optional(),
 });
 
 export class CreateDesertTripDto extends createZodDto(createDesertTripSchema) {}

--- a/services/map/src/site-status/dto/status-board-query.dto.ts
+++ b/services/map/src/site-status/dto/status-board-query.dto.ts
@@ -1,5 +1,11 @@
 import { createZodDto } from 'nestjs-zod';
+import { z } from 'zod';
 
 import { paginationSchema } from '../../utils/schemas';
 
-export class StatusBoardQueryDto extends createZodDto(paginationSchema) {}
+const statusBoardQuerySchema = paginationSchema.extend({
+  search: z.string().optional(),
+  status: z.string().optional(),
+});
+
+export class StatusBoardQueryDto extends createZodDto(statusBoardQuerySchema) {}

--- a/services/map/src/site-status/site-status.service.ts
+++ b/services/map/src/site-status/site-status.service.ts
@@ -8,7 +8,7 @@ import {
   Injectable,
   NotFoundException,
 } from '@nestjs/common';
-import { and, count, eq, isNull, sql } from 'drizzle-orm';
+import { and, count, eq, ilike, isNull, or, sql } from 'drizzle-orm';
 import type { Column } from 'drizzle-orm';
 import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
 
@@ -89,6 +89,8 @@ export class SiteStatusService {
   async getStatusBoard(params: {
     page: number;
     limit: number;
+    search?: string;
+    status?: string;
   }): Promise<PaginatedResponse<PoiWithStatus>> {
     const offset = (params.page - 1) * params.limit;
 
@@ -98,7 +100,23 @@ export class SiteStatusService {
     const noteEnSq = latestStatusField(siteStatusUpdates.noteEn);
     const validUntilSq = latestStatusField(siteStatusUpdates.validUntil);
 
-    const where = and(eq(pointsOfInterest.status, 'approved'), isNull(pointsOfInterest.deletedAt));
+    const searchCondition = params.search
+      ? or(
+          ilike(pointsOfInterest.nameAr, `%${params.search}%`),
+          ilike(pointsOfInterest.nameEn, `%${params.search}%`),
+        )
+      : undefined;
+
+    const statusCondition = params.status
+      ? sql`(SELECT status FROM ${siteStatusUpdates} WHERE ${siteStatusUpdates.poiId} = ${pointsOfInterest.id} ORDER BY ${siteStatusUpdates.createdAt} DESC, ${siteStatusUpdates.id} DESC LIMIT 1) = ${params.status}`
+      : undefined;
+
+    const where = and(
+      eq(pointsOfInterest.status, 'approved'),
+      isNull(pointsOfInterest.deletedAt),
+      searchCondition,
+      statusCondition,
+    );
 
     const [data, countRows] = await Promise.all([
       this.db

--- a/services/map/src/site-status/site-status.service.ts
+++ b/services/map/src/site-status/site-status.service.ts
@@ -14,6 +14,7 @@ import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
 
 import { pointsOfInterest, siteStatusUpdates, siteStewards } from '../db/schema/index';
 import { isUniqueViolation } from '../utils/db';
+import { escapeLike } from '../utils/query';
 
 import type { CreateStatusDto } from './dto';
 
@@ -102,8 +103,8 @@ export class SiteStatusService {
 
     const searchCondition = params.search
       ? or(
-          ilike(pointsOfInterest.nameAr, `%${params.search}%`),
-          ilike(pointsOfInterest.nameEn, `%${params.search}%`),
+          ilike(pointsOfInterest.nameAr, `%${escapeLike(params.search)}%`),
+          ilike(pointsOfInterest.nameEn, `%${escapeLike(params.search)}%`),
         )
       : undefined;
 

--- a/services/map/src/site-status/status-board.controller.ts
+++ b/services/map/src/site-status/status-board.controller.ts
@@ -11,6 +11,11 @@ export class StatusBoardController {
   @Public()
   @Get('status-board')
   getStatusBoard(@Query() query: StatusBoardQueryDto) {
-    return this.siteStatusService.getStatusBoard({ page: query.page, limit: query.limit });
+    return this.siteStatusService.getStatusBoard({
+      page: query.page,
+      limit: query.limit,
+      search: query.search,
+      status: query.status,
+    });
   }
 }


### PR DESCRIPTION
## Summary

- **Desert trip safety panel** — guides can register a trip plan (destination, emergency contact, expected arrival, nearest ranger post) directly from their active bookings; tourists see the live status; guides can check in on arrival
- **Site status board page** — new `/tourism/sites` route with searchable, filterable grid of POI statuses (backed by the map service)
- **Schema fix** — `ranger_station_id uuid` renamed to `ranger_station_name text`, removing the implicit cross-schema FK coupling

## Changes

| Layer | What changed |
|---|---|
| `guide-booking` schema | `ranger_station_id uuid` → `ranger_station_name text` + migration |
| `map` service | `GET /sites/status-board` now accepts `search` and `status` query params |
| `web` API client | `desertTripsAPI`, `mapAPI.getStatusBoard`, `PoiWithStatus`, `DesertTrip` types |
| `web` hooks | `useDesertTrip`, `useRegisterDesertTrip`, `useCheckInDesertTrip`, `useStatusBoard` |
| `web` components | `DesertTripPanel`, `RegisterTripForm`, `TripStatusCard` |
| `web` pages | `SiteStatusBoardPage` at `/tourism/sites` |
| `web` BookingsPage | Desert trip panel on active bookings, Arabic plural fix, guide-aware empty state |

## Test plan

- [ ] `pnpm --filter @hena-wadeena/guide-booking test` — `desert-trips.service.spec.ts` passes with renamed field
- [ ] `pnpm --filter @hena-wadeena/web test` — `use-desert-trip.spec.ts` passes (9 cases)
- [ ] Guide flow: open an active booking → register a trip plan → check in → status updates to `checked_in`
- [ ] Tourist flow: open an active booking with a registered plan → status card visible, no actions
- [ ] Status board: `/tourism/sites` loads, search filters by name, pagination works