### PR TITLE
fix(market): split job-post schema to allow partial() on update DTO

### DIFF
--- a/services/market/src/job-posts/dto/job-post.schema.ts
+++ b/services/market/src/job-posts/dto/job-post.schema.ts
@@ -15,13 +15,18 @@ export const jobPostBaseSchema = z.object({
   endsAt: z.iso.datetime().optional(),
 });
 
-export const createJobPostSchema = jobPostBaseSchema.refine(
-  (data) => {
-    if (!data.startsAt || !data.endsAt) return true;
-    return new Date(data.endsAt).getTime() >= new Date(data.startsAt).getTime();
-  },
-  {
-    path: ['endsAt'],
-    message: 'endsAt must be on or after startsAt',
-  },
-);
+const validateDateRange = (data: { startsAt?: string; endsAt?: string }) => {
+  if (!data.startsAt || !data.endsAt) return true;
+  return new Date(data.endsAt).getTime() >= new Date(data.startsAt).getTime();
+};
+
+const dateRangeError = {
+  path: ['endsAt'],
+  message: 'endsAt must be on or after startsAt',
+};
+
+export const createJobPostSchema = jobPostBaseSchema.refine(validateDateRange, dateRangeError);
+
+export const updateJobPostSchema = jobPostBaseSchema
+  .partial()
+  .refine(validateDateRange, dateRangeError);

--- a/services/market/src/job-posts/dto/job-post.schema.ts
+++ b/services/market/src/job-posts/dto/job-post.schema.ts
@@ -1,29 +1,27 @@
-import { CompensationType, JobCategory } from '@hena-wadeena/types';
 import { z } from 'zod';
 
-const jobCategories = Object.values(JobCategory) as [string, ...string[]];
-const compensationTypes = Object.values(CompensationType) as [string, ...string[]];
+import { COMPENSATION_TYPES, JOB_CATEGORIES } from '../../jobs/jobs.types';
 
-export const createJobPostSchema = z
-  .object({
-    title: z.string().min(3).max(255),
-    descriptionAr: z.string().min(10),
-    descriptionEn: z.string().optional(),
-    category: z.enum(jobCategories),
-    area: z.string(),
-    compensation: z.number().int().min(0),
-    compensationType: z.enum(compensationTypes),
-    slots: z.number().int().min(1),
-    startsAt: z.iso.datetime().optional(),
-    endsAt: z.iso.datetime().optional(),
-  })
-  .refine(
-    (data) => {
-      if (!data.startsAt || !data.endsAt) return true;
-      return new Date(data.endsAt).getTime() >= new Date(data.startsAt).getTime();
-    },
-    {
-      path: ['endsAt'],
-      message: 'endsAt must be on or after startsAt',
-    },
-  );
+export const jobPostBaseSchema = z.object({
+  title: z.string().min(3).max(255),
+  descriptionAr: z.string().min(10),
+  descriptionEn: z.string().optional(),
+  category: z.enum(JOB_CATEGORIES),
+  area: z.string(),
+  compensation: z.number().int().min(0),
+  compensationType: z.enum(COMPENSATION_TYPES),
+  slots: z.number().int().min(1),
+  startsAt: z.iso.datetime().optional(),
+  endsAt: z.iso.datetime().optional(),
+});
+
+export const createJobPostSchema = jobPostBaseSchema.refine(
+  (data) => {
+    if (!data.startsAt || !data.endsAt) return true;
+    return new Date(data.endsAt).getTime() >= new Date(data.startsAt).getTime();
+  },
+  {
+    path: ['endsAt'],
+    message: 'endsAt must be on or after startsAt',
+  },
+);

--- a/services/market/src/job-posts/dto/update-job-post.dto.ts
+++ b/services/market/src/job-posts/dto/update-job-post.dto.ts
@@ -1,5 +1,5 @@
 import { createZodDto } from 'nestjs-zod';
 
-import { createJobPostSchema } from './job-post.schema';
+import { jobPostBaseSchema } from './job-post.schema';
 
-export class UpdateJobPostDto extends createZodDto(createJobPostSchema.partial()) {}
+export class UpdateJobPostDto extends createZodDto(jobPostBaseSchema.partial()) {}

--- a/services/market/src/job-posts/dto/update-job-post.dto.ts
+++ b/services/market/src/job-posts/dto/update-job-post.dto.ts
@@ -1,5 +1,5 @@
 import { createZodDto } from 'nestjs-zod';
 
-import { jobPostBaseSchema } from './job-post.schema';
+import { updateJobPostSchema } from './job-post.schema';
 
-export class UpdateJobPostDto extends createZodDto(jobPostBaseSchema.partial()) {}
+export class UpdateJobPostDto extends createZodDto(updateJobPostSchema) {}

--- a/services/market/src/job-posts/job-posts.service.ts
+++ b/services/market/src/job-posts/job-posts.service.ts
@@ -40,10 +40,10 @@ export class JobPostsService {
           title: dto.title,
           descriptionAr: dto.descriptionAr,
           descriptionEn: dto.descriptionEn ?? null,
-          category: dto.category as InsertJobPost['category'],
+          category: dto.category,
           area: dto.area,
           compensation: dto.compensation,
-          compensationType: dto.compensationType as InsertJobPost['compensationType'],
+          compensationType: dto.compensationType,
           slots: dto.slots,
           startsAt: dto.startsAt ? new Date(dto.startsAt) : undefined,
           endsAt: dto.endsAt ? new Date(dto.endsAt) : undefined,
@@ -137,11 +137,11 @@ export class JobPostsService {
     if (dto.title !== undefined) updates.title = dto.title;
     if (dto.descriptionAr !== undefined) updates.descriptionAr = dto.descriptionAr;
     if (dto.descriptionEn !== undefined) updates.descriptionEn = dto.descriptionEn;
-    if (dto.category !== undefined) updates.category = dto.category as InsertJobPost['category'];
+    if (dto.category !== undefined) updates.category = dto.category;
     if (dto.area !== undefined) updates.area = dto.area;
     if (dto.compensation !== undefined) updates.compensation = dto.compensation;
     if (dto.compensationType !== undefined)
-      updates.compensationType = dto.compensationType as InsertJobPost['compensationType'];
+      updates.compensationType = dto.compensationType;
     if (dto.slots !== undefined) updates.slots = dto.slots;
     if (dto.startsAt !== undefined) updates.startsAt = new Date(dto.startsAt);
     if (dto.endsAt !== undefined) updates.endsAt = new Date(dto.endsAt);


### PR DESCRIPTION
## Problem

After PR #134 (t36 employment board), the market service was crashing on startup with exit code 1, making every deploy fail with `container hena-wadeena-market-1 is unhealthy`.

Root cause from production logs:
```
Error: .partial() cannot be used on object schemas containing refinements
    at Object.<anonymous> (/app/services/market/dist/job-posts/dto/update-job-post.dto.js:6:101)
```

Zod v4 throws at **module load time** when `.partial()` is called on a schema that has a `.refine()`. `createJobPostSchema` had a date-range refinement, and `UpdateJobPostDto` was calling `createJobPostSchema.partial()`.

## Fix

- Extract `jobPostBaseSchema` (plain object, no refinement) — this is safe to `.partial()`
- Keep `createJobPostSchema = jobPostBaseSchema.refine(...)` for create validation (date range check unchanged)
- `UpdateJobPostDto` now uses `jobPostBaseSchema.partial()`
- Replace `Object.values(JobCategory/CompensationType) as [string, ...string[]]` with existing `JOB_CATEGORIES` / `COMPENSATION_TYPES` const tuples from `jobs.types.ts` to fix `no-unsafe-argument` lint errors

## Why CI didn't catch it

TypeScript doesn't type-check Zod refinements at compile time. The error only surfaces at runtime when Node.js loads the module.