### PR TITLE
fix(db): add db:reset/db:migrate scripts and repair market snapshot chain

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,9 @@
 # PostgreSQL connection (all NestJS services share this)
 # Format: postgresql://user:password@localhost:5432/dbname
 DATABASE_URL=
+# Host-side URL for scripts that run outside Docker (db:reset, etc.)
+# Same as DATABASE_URL but with localhost instead of the container hostname
+DATABASE_URL_LOCAL=
 # Schema name for the service (e.g., identity, market, guide_booking, map, ai)
 DB_SCHEMA=
 POSTGRES_USER=

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help setup infra infra-down dev web ai build test validate health logs seed clean
+.PHONY: help setup infra infra-down dev web ai build test validate health logs db-migrate db-reset seed clean
 
 DC = docker compose -f docker-compose.yml -f docker-compose.dev.yml
 
@@ -15,6 +15,8 @@ help:
 	@echo "  validate    lint + typecheck + test + knip + audit + build"
 	@echo "  health      ping all /health endpoints"
 	@echo "  logs        tail infrastructure container logs"
+	@echo "  db-migrate  run all service migrations"
+	@echo "  db-reset    drop all schemas + clear migration tracking (local dev only)"
 	@echo "  seed        seed all service databases"
 	@echo "  clean       stop containers, remove volumes + dist folders"
 	@echo ""
@@ -64,6 +66,15 @@ health:
 	@echo "── ai           " && curl -sf --max-time 5 http://localhost:8005/health && echo "OK" || echo "FAIL"
 
 # ── Database ──────────────────────────────────────────────────────────────────
+db-migrate:
+	pnpm --filter @hena-wadeena/identity run db:migrate
+	pnpm --filter @hena-wadeena/market run db:migrate
+	pnpm --filter @hena-wadeena/guide-booking run db:migrate
+	pnpm --filter @hena-wadeena/map run db:migrate
+
+db-reset:
+	pnpm db:reset
+
 seed:
 	pnpm --filter @hena-wadeena/identity run db:seed
 	pnpm --filter @hena-wadeena/market run db:seed

--- a/package.json
+++ b/package.json
@@ -24,6 +24,8 @@
     "format:check": "prettier --check .",
     "knip": "knip",
     "validate": "pnpm build && pnpm lint && pnpm typecheck && pnpm test && pnpm knip && pnpm audit --audit-level=high",
+    "db:migrate": "pnpm --filter @hena-wadeena/identity run db:migrate && pnpm --filter @hena-wadeena/market run db:migrate && pnpm --filter @hena-wadeena/guide-booking run db:migrate && pnpm --filter @hena-wadeena/map run db:migrate",
+    "db:reset": "node --env-file .env --import tsx scripts/db-reset.ts",
     "db:seed": "pnpm --filter @hena-wadeena/identity run db:seed && pnpm --filter @hena-wadeena/market run db:seed && pnpm --filter @hena-wadeena/guide-booking run db:seed && pnpm --filter @hena-wadeena/map run db:seed",
     "db:seed:showcase": "pnpm --filter @hena-wadeena/identity run db:seed:showcase && pnpm --filter @hena-wadeena/market run db:seed:showcase && pnpm --filter @hena-wadeena/guide-booking run db:seed:showcase && pnpm --filter @hena-wadeena/map run db:seed:showcase"
   },
@@ -38,7 +40,9 @@
     "eslint-plugin-import": "^2.31.0",
     "knip": "^5.40.0",
     "lefthook": "^2.1.3",
+    "postgres": "^3.4.5",
     "prettier": "^3.4.2",
+    "tsx": "^4.19.0",
     "typescript": "^5.7.3",
     "typescript-eslint": "^8.20.0",
     "unplugin-swc": "^1.5.9",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,16 +41,22 @@ importers:
         version: 9.39.4(jiti@2.6.1)
       eslint-plugin-import:
         specifier: ^2.31.0
-        version: 2.32.0(eslint@9.39.4(jiti@2.6.1))
+        version: 2.32.0(@typescript-eslint/parser@8.57.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))
       knip:
         specifier: ^5.40.0
         version: 5.86.0(@types/node@22.19.15)(typescript@5.9.3)
       lefthook:
         specifier: ^2.1.3
         version: 2.1.3
+      postgres:
+        specifier: ^3.4.5
+        version: 3.4.8
       prettier:
         specifier: ^3.4.2
         version: 3.8.1
+      tsx:
+        specifier: ^4.19.0
+        version: 4.21.0
       typescript:
         specifier: ^5.7.3
         version: 5.9.3
@@ -9486,10 +9492,10 @@ snapshots:
 
   '@types/trusted-types@2.0.7': {}
 
-  '@typescript-eslint/eslint-plugin@8.57.0(@typescript-eslint/parser@8.57.0(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3))(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3)':
+  '@typescript-eslint/eslint-plugin@8.57.0(@typescript-eslint/parser@8.57.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 8.57.0(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.57.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
       '@typescript-eslint/scope-manager': 8.57.0
       '@typescript-eslint/type-utils': 8.57.0(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3)
       '@typescript-eslint/utils': 8.57.0(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3)
@@ -10603,16 +10609,17 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(eslint-import-resolver-node@0.3.9)(eslint@9.39.4(jiti@2.6.1)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.57.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint@9.39.4(jiti@2.6.1)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
+      '@typescript-eslint/parser': 8.57.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
       eslint: 9.39.4(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.6.1)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.57.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -10623,7 +10630,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.4(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(eslint-import-resolver-node@0.3.9)(eslint@9.39.4(jiti@2.6.1))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.57.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint@9.39.4(jiti@2.6.1))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -10634,6 +10641,8 @@ snapshots:
       semver: 6.3.1
       string.prototype.trimend: 1.0.9
       tsconfig-paths: 3.15.0
+    optionalDependencies:
+      '@typescript-eslint/parser': 8.57.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
@@ -12739,7 +12748,7 @@ snapshots:
 
   typescript-eslint@8.57.0(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.57.0(@typescript-eslint/parser@8.57.0(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3))(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3)
+      '@typescript-eslint/eslint-plugin': 8.57.0(@typescript-eslint/parser@8.57.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3)
       '@typescript-eslint/parser': 8.57.0(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3)
       '@typescript-eslint/typescript-estree': 8.57.0(typescript@5.9.3)
       '@typescript-eslint/utils': 8.57.0(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3)

--- a/scripts/db-reset.ts
+++ b/scripts/db-reset.ts
@@ -1,0 +1,53 @@
+/**
+ * db-reset.ts
+ *
+ * Drops all service schemas and clears Drizzle migration tracking so that
+ * a subsequent `db:migrate` starts from a blank slate.
+ *
+ * Usage (from monorepo root):
+ *   node --env-file .env --import tsx scripts/db-reset.ts
+ *
+ * Env vars:
+ *   DATABASE_URL_LOCAL  – preferred; postgres reachable from the host (localhost)
+ *   DATABASE_URL        – fallback; Docker-internal hostname works from containers only
+ */
+
+import postgres from 'postgres';
+
+const connectionString = process.env.DATABASE_URL_LOCAL ?? process.env.DATABASE_URL;
+if (!connectionString) throw new Error('DATABASE_URL_LOCAL or DATABASE_URL is required');
+
+const sql = postgres(connectionString, { max: 1 });
+
+const TRACKING_TABLES = [
+  { schema: 'drizzle', name: '__drizzle_migrations_identity' },
+  { schema: 'drizzle', name: '__drizzle_migrations_market' },
+  { schema: 'drizzle', name: '__drizzle_migrations_guide_booking' },
+  { schema: 'drizzle', name: '__drizzle_migrations_map' },
+] as const;
+
+async function main() {
+  console.warn('[db-reset] Dropping service schemas...');
+  await sql`DROP SCHEMA IF EXISTS identity CASCADE`;
+  await sql`DROP SCHEMA IF EXISTS market CASCADE`;
+  await sql`DROP SCHEMA IF EXISTS guide_booking CASCADE`;
+  await sql`DROP SCHEMA IF EXISTS map CASCADE`;
+  await sql`DROP SCHEMA IF EXISTS ai CASCADE`;
+  console.warn('[db-reset] Schemas dropped.');
+
+  // Clear Drizzle migration tracking so the next `db:migrate` re-applies all
+  // migrations. The tracking tables live in the shared `drizzle` schema which
+  // survives schema drops.
+  for (const { schema, name } of TRACKING_TABLES) {
+    await sql`TRUNCATE ${sql(schema)}.${sql(name)}`;
+    console.warn(`[db-reset] Cleared ${schema}.${name}`);
+  }
+
+  console.warn('[db-reset] Done. Run db:migrate then db:seed to restore data.');
+  await sql.end();
+}
+
+main().catch((err: unknown) => {
+  console.error('[db-reset] Failed:', err instanceof Error ? err.message : String(err));
+  process.exit(1);
+});

--- a/scripts/db-reset.ts
+++ b/scripts/db-reset.ts
@@ -10,12 +10,23 @@
  * Env vars:
  *   DATABASE_URL_LOCAL  – preferred; postgres reachable from the host (localhost)
  *   DATABASE_URL        – fallback; Docker-internal hostname works from containers only
+ *   ALLOW_DB_RESET=1    – override the localhost-only safety gate (use with care)
  */
 
 import postgres from 'postgres';
 
 const connectionString = process.env.DATABASE_URL_LOCAL ?? process.env.DATABASE_URL;
 if (!connectionString) throw new Error('DATABASE_URL_LOCAL or DATABASE_URL is required');
+
+// Safety gate: refuse to run against non-local hosts unless explicitly overridden.
+const parsed = new URL(connectionString);
+const allowedHosts = new Set(['localhost', '127.0.0.1', 'postgres']);
+if (!allowedHosts.has(parsed.hostname) && process.env.ALLOW_DB_RESET !== '1') {
+  throw new Error(
+    `[db-reset] Refusing to run against host "${parsed.hostname}". ` +
+      `Set ALLOW_DB_RESET=1 to override intentionally.`,
+  );
+}
 
 const sql = postgres(connectionString, { max: 1 });
 
@@ -37,10 +48,19 @@ async function main() {
 
   // Clear Drizzle migration tracking so the next `db:migrate` re-applies all
   // migrations. The tracking tables live in the shared `drizzle` schema which
-  // survives schema drops.
+  // survives schema drops. Guard each TRUNCATE against missing tables (fresh DB
+  // or partially migrated state) since PostgreSQL TRUNCATE has no IF EXISTS.
   for (const { schema, name } of TRACKING_TABLES) {
-    await sql`TRUNCATE ${sql(schema)}.${sql(name)}`;
-    console.warn(`[db-reset] Cleared ${schema}.${name}`);
+    const [row] = await sql`
+      SELECT 1 FROM information_schema.tables
+      WHERE table_schema = ${schema} AND table_name = ${name}
+    `;
+    if (row) {
+      await sql`TRUNCATE ${sql(schema)}.${sql(name)}`;
+      console.warn(`[db-reset] Cleared ${schema}.${name}`);
+    } else {
+      console.warn(`[db-reset] Skipped ${schema}.${name} (not found)`);
+    }
   }
 
   console.warn('[db-reset] Done. Run db:migrate then db:seed to restore data.');

--- a/scripts/tsconfig.json
+++ b/scripts/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "./dist",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext"
+  },
+  "include": ["*.ts"]
+}

--- a/services/market/drizzle/20260415101709_mysterious_tana_nile.sql
+++ b/services/market/drizzle/20260415101709_mysterious_tana_nile.sql
@@ -1,0 +1,25 @@
+CREATE TYPE "market"."news_category" AS ENUM('announcement', 'tourism', 'investment', 'agriculture', 'infrastructure', 'culture', 'events');--> statement-breakpoint
+CREATE TABLE "market"."news_articles" (
+	"id" uuid PRIMARY KEY NOT NULL,
+	"title_ar" text NOT NULL,
+	"summary_ar" text NOT NULL,
+	"content_ar" text NOT NULL,
+	"slug" text NOT NULL,
+	"category" "market"."news_category" NOT NULL,
+	"cover_image" text,
+	"author_id" uuid,
+	"author_name" text NOT NULL,
+	"reading_time_minutes" integer DEFAULT 1 NOT NULL,
+	"is_published" boolean DEFAULT false NOT NULL,
+	"published_at" timestamp with time zone,
+	"view_count" integer DEFAULT 0 NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"deleted_at" timestamp with time zone,
+	CONSTRAINT "news_articles_slug_unique" UNIQUE("slug")
+);
+--> statement-breakpoint
+ALTER TABLE "market"."job_posts" DROP CONSTRAINT "job_posts_valid_date_range";--> statement-breakpoint
+CREATE INDEX "idx_news_category_published" ON "market"."news_articles" USING btree ("category","is_published","published_at");--> statement-breakpoint
+CREATE INDEX "idx_news_deleted_at" ON "market"."news_articles" USING btree ("deleted_at");--> statement-breakpoint
+ALTER TABLE "market"."job_posts" ADD CONSTRAINT "job_posts_valid_date_range" CHECK ("market"."job_posts"."starts_at" IS NULL OR "market"."job_posts"."ends_at" IS NULL OR "market"."job_posts"."ends_at" >= "market"."job_posts"."starts_at");

--- a/services/market/drizzle/meta/20260407100216_snapshot.json
+++ b/services/market/drizzle/meta/20260407100216_snapshot.json
@@ -1,6 +1,6 @@
 {
   "id": "be88cb0f-78b2-4d8b-a354-982e294c7f4c",
-  "prevId": "fb3aa203-4a08-4eb3-9d27-0d69a8ac434b",
+  "prevId": "82a4d8da-70a1-4fdc-aed5-e67edd73a620",
   "version": "7",
   "dialect": "postgresql",
   "tables": {

--- a/services/market/drizzle/meta/20260408053352_snapshot.json
+++ b/services/market/drizzle/meta/20260408053352_snapshot.json
@@ -1,6 +1,6 @@
 {
   "id": "3a18aa11-b1c8-481e-8748-6f926343c0a2",
-  "prevId": "fb3aa203-4a08-4eb3-9d27-0d69a8ac434b",
+  "prevId": "9c193c7c-7426-44df-90ea-a03a2fc7da23",
   "version": "7",
   "dialect": "postgresql",
   "tables": {

--- a/services/market/drizzle/meta/20260408055856_snapshot.json
+++ b/services/market/drizzle/meta/20260408055856_snapshot.json
@@ -1,6 +1,6 @@
 {
   "id": "d4b73b2b-8dcd-45a4-89d6-5b0f4d2b6a05",
-  "prevId": "82a4d8da-70a1-4fdc-aed5-e67edd73a620",
+  "prevId": "3a18aa11-b1c8-481e-8748-6f926343c0a2",
   "version": "7",
   "dialect": "postgresql",
   "tables": {

--- a/services/market/drizzle/meta/20260415101709_snapshot.json
+++ b/services/market/drizzle/meta/20260415101709_snapshot.json
@@ -1,6 +1,6 @@
 {
-  "id": "9c193c7c-7426-44df-90ea-a03a2fc7da23",
-  "prevId": "be88cb0f-78b2-4d8b-a354-982e294c7f4c",
+  "id": "97029acf-8f18-4583-9938-bd944eccfa3e",
+  "prevId": "8827cd1e-3efd-483b-8dd6-c7cc5659e0a8",
   "version": "7",
   "dialect": "postgresql",
   "tables": {
@@ -1355,6 +1355,538 @@
       },
       "isRLSEnabled": false
     },
+    "market.job_applications": {
+      "name": "job_applications",
+      "schema": "market",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "job_id": {
+          "name": "job_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "applicant_id": {
+          "name": "applicant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note_ar": {
+          "name": "note_ar",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "job_application_status",
+          "typeSchema": "market",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "applied_at": {
+          "name": "applied_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_job_applications_job_id": {
+          "name": "idx_job_applications_job_id",
+          "columns": [
+            {
+              "expression": "job_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_job_applications_applicant_id": {
+          "name": "idx_job_applications_applicant_id",
+          "columns": [
+            {
+              "expression": "applicant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_job_applications_status": {
+          "name": "idx_job_applications_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_job_applications_applied_at": {
+          "name": "idx_job_applications_applied_at",
+          "columns": [
+            {
+              "expression": "applied_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "job_applications_job_id_job_posts_id_fk": {
+          "name": "job_applications_job_id_job_posts_id_fk",
+          "tableFrom": "job_applications",
+          "tableTo": "job_posts",
+          "schemaTo": "market",
+          "columnsFrom": [
+            "job_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "job_applications_applicant_job_unique": {
+          "name": "job_applications_applicant_job_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "applicant_id",
+            "job_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "market.job_posts": {
+      "name": "job_posts",
+      "schema": "market",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "poster_id": {
+          "name": "poster_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description_ar": {
+          "name": "description_ar",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description_en": {
+          "name": "description_en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "job_category",
+          "typeSchema": "market",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "area": {
+          "name": "area",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "compensation": {
+          "name": "compensation",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "compensation_type": {
+          "name": "compensation_type",
+          "type": "compensation_type",
+          "typeSchema": "market",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slots": {
+          "name": "slots",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "status": {
+          "name": "status",
+          "type": "job_status",
+          "typeSchema": "market",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "starts_at": {
+          "name": "starts_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ends_at": {
+          "name": "ends_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_job_posts_poster_id": {
+          "name": "idx_job_posts_poster_id",
+          "columns": [
+            {
+              "expression": "poster_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_job_posts_status": {
+          "name": "idx_job_posts_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_job_posts_category": {
+          "name": "idx_job_posts_category",
+          "columns": [
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_job_posts_area": {
+          "name": "idx_job_posts_area",
+          "columns": [
+            {
+              "expression": "area",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_job_posts_created_at": {
+          "name": "idx_job_posts_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "job_posts_compensation_non_negative": {
+          "name": "job_posts_compensation_non_negative",
+          "value": "\"market\".\"job_posts\".\"compensation\" >= 0"
+        },
+        "job_posts_slots_positive": {
+          "name": "job_posts_slots_positive",
+          "value": "\"market\".\"job_posts\".\"slots\" >= 1"
+        },
+        "job_posts_valid_date_range": {
+          "name": "job_posts_valid_date_range",
+          "value": "\"market\".\"job_posts\".\"starts_at\" IS NULL OR \"market\".\"job_posts\".\"ends_at\" IS NULL OR \"market\".\"job_posts\".\"ends_at\" >= \"market\".\"job_posts\".\"starts_at\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "market.job_reviews": {
+      "name": "job_reviews",
+      "schema": "market",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "job_id": {
+          "name": "job_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "application_id": {
+          "name": "application_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reviewer_id": {
+          "name": "reviewer_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reviewee_id": {
+          "name": "reviewee_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "direction": {
+          "name": "direction",
+          "type": "review_direction",
+          "typeSchema": "market",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rating": {
+          "name": "rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "job_reviews_application_direction_unique": {
+          "name": "job_reviews_application_direction_unique",
+          "columns": [
+            {
+              "expression": "application_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "direction",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_job_reviews_reviewer_id": {
+          "name": "idx_job_reviews_reviewer_id",
+          "columns": [
+            {
+              "expression": "reviewer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_job_reviews_reviewee_id": {
+          "name": "idx_job_reviews_reviewee_id",
+          "columns": [
+            {
+              "expression": "reviewee_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_job_reviews_created_at": {
+          "name": "idx_job_reviews_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "job_reviews_job_id_job_posts_id_fk": {
+          "name": "job_reviews_job_id_job_posts_id_fk",
+          "tableFrom": "job_reviews",
+          "tableTo": "job_posts",
+          "schemaTo": "market",
+          "columnsFrom": [
+            "job_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "job_reviews_application_id_job_applications_id_fk": {
+          "name": "job_reviews_application_id_job_applications_id_fk",
+          "tableFrom": "job_reviews",
+          "tableTo": "job_applications",
+          "schemaTo": "market",
+          "columnsFrom": [
+            "application_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "job_reviews_rating_range": {
+          "name": "job_reviews_rating_range",
+          "value": "\"market\".\"job_reviews\".\"rating\" >= 1 AND \"market\".\"job_reviews\".\"rating\" <= 5"
+        }
+      },
+      "isRLSEnabled": false
+    },
     "market.listing_inquiries": {
       "name": "listing_inquiries",
       "schema": "market",
@@ -1972,6 +2504,277 @@
       },
       "isRLSEnabled": false
     },
+    "market.news_articles": {
+      "name": "news_articles",
+      "schema": "market",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title_ar": {
+          "name": "title_ar",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary_ar": {
+          "name": "summary_ar",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_ar": {
+          "name": "content_ar",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "news_category",
+          "typeSchema": "market",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cover_image": {
+          "name": "cover_image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_name": {
+          "name": "author_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reading_time_minutes": {
+          "name": "reading_time_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "is_published": {
+          "name": "is_published",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "view_count": {
+          "name": "view_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_news_category_published": {
+          "name": "idx_news_category_published",
+          "columns": [
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_published",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "published_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_news_deleted_at": {
+          "name": "idx_news_deleted_at",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "news_articles_slug_unique": {
+          "name": "news_articles_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "market.price_alert_subscriptions": {
+      "name": "price_alert_subscriptions",
+      "schema": "market",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "commodity_id": {
+          "name": "commodity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "threshold_price": {
+          "name": "threshold_price",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "direction": {
+          "name": "direction",
+          "type": "alert_direction",
+          "typeSchema": "market",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "last_triggered_at": {
+          "name": "last_triggered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_price_alert_commodity": {
+          "name": "idx_price_alert_commodity",
+          "columns": [
+            {
+              "expression": "commodity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "price_alert_subscriptions_commodity_id_commodities_id_fk": {
+          "name": "price_alert_subscriptions_commodity_id_commodities_id_fk",
+          "tableFrom": "price_alert_subscriptions",
+          "tableTo": "commodities",
+          "schemaTo": "market",
+          "columnsFrom": [
+            "commodity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "price_alert_subscriptions_user_id_commodity_id_direction_unique": {
+          "name": "price_alert_subscriptions_user_id_commodity_id_direction_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "commodity_id",
+            "direction"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
     "market.price_snapshots": {
       "name": "price_snapshots",
       "schema": "market",
@@ -2104,6 +2907,105 @@
           "value": "\"market\".\"price_snapshots\".\"sample_count\" >= 0"
         }
       },
+      "isRLSEnabled": false
+    },
+    "market.produce_listing_details": {
+      "name": "produce_listing_details",
+      "schema": "market",
+      "columns": {
+        "listing_id": {
+          "name": "listing_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "commodity_type": {
+          "name": "commodity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity_kg": {
+          "name": "quantity_kg",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "harvest_date": {
+          "name": "harvest_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "storage_type": {
+          "name": "storage_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "certifications": {
+          "name": "certifications",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "preferred_buyer": {
+          "name": "preferred_buyer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_phone": {
+          "name": "contact_phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_whatsapp": {
+          "name": "contact_whatsapp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_produce_commodity_type": {
+          "name": "idx_produce_commodity_type",
+          "columns": [
+            {
+              "expression": "commodity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "produce_listing_details_listing_id_listings_id_fk": {
+          "name": "produce_listing_details_listing_id_listings_id_fk",
+          "tableFrom": "produce_listing_details",
+          "tableTo": "listings",
+          "schemaTo": "market",
+          "columnsFrom": [
+            "listing_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
       "isRLSEnabled": false
     },
     "market.review_helpful_votes": {
@@ -2345,9 +3247,165 @@
         }
       },
       "isRLSEnabled": false
+    },
+    "market.well_logs": {
+      "name": "well_logs",
+      "schema": "market",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "farmer_id": {
+          "name": "farmer_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location": {
+          "name": "location",
+          "type": "geometry(point)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "area": {
+          "name": "area",
+          "type": "well_area",
+          "typeSchema": "market",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pump_hours": {
+          "name": "pump_hours",
+          "type": "numeric(6, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kwh_consumed": {
+          "name": "kwh_consumed",
+          "type": "numeric(8, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cost_piasters": {
+          "name": "cost_piasters",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "water_m3_est": {
+          "name": "water_m3_est",
+          "type": "numeric(8, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "depth_to_water_m": {
+          "name": "depth_to_water_m",
+          "type": "numeric(6, 1)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "logged_at": {
+          "name": "logged_at",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_well_logs_farmer_id": {
+          "name": "idx_well_logs_farmer_id",
+          "columns": [
+            {
+              "expression": "farmer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_well_logs_area": {
+          "name": "idx_well_logs_area",
+          "columns": [
+            {
+              "expression": "area",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_well_logs_logged_at": {
+          "name": "idx_well_logs_logged_at",
+          "columns": [
+            {
+              "expression": "logged_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chk_well_logs_pump_hours_non_neg": {
+          "name": "chk_well_logs_pump_hours_non_neg",
+          "value": "\"market\".\"well_logs\".\"pump_hours\" >= 0"
+        },
+        "chk_well_logs_kwh_consumed_non_neg": {
+          "name": "chk_well_logs_kwh_consumed_non_neg",
+          "value": "\"market\".\"well_logs\".\"kwh_consumed\" >= 0"
+        },
+        "chk_well_logs_cost_piasters_non_neg": {
+          "name": "chk_well_logs_cost_piasters_non_neg",
+          "value": "\"market\".\"well_logs\".\"cost_piasters\" >= 0"
+        },
+        "chk_well_logs_water_m3_est_non_neg": {
+          "name": "chk_well_logs_water_m3_est_non_neg",
+          "value": "\"market\".\"well_logs\".\"water_m3_est\" >= 0"
+        },
+        "chk_well_logs_depth_to_water_m_non_neg": {
+          "name": "chk_well_logs_depth_to_water_m_non_neg",
+          "value": "\"market\".\"well_logs\".\"depth_to_water_m\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
     }
   },
   "enums": {
+    "market.alert_direction": {
+      "name": "alert_direction",
+      "schema": "market",
+      "values": [
+        "above",
+        "below"
+      ]
+    },
     "market.application_status": {
       "name": "application_status",
       "schema": "market",
@@ -2401,6 +3459,16 @@
         "box"
       ]
     },
+    "market.compensation_type": {
+      "name": "compensation_type",
+      "schema": "market",
+      "values": [
+        "fixed",
+        "daily",
+        "per_kg",
+        "negotiable"
+      ]
+    },
     "market.investment_sector": {
       "name": "investment_sector",
       "schema": "market",
@@ -2412,6 +3480,41 @@
         "services",
         "technology",
         "energy"
+      ]
+    },
+    "market.job_application_status": {
+      "name": "job_application_status",
+      "schema": "market",
+      "values": [
+        "pending",
+        "accepted",
+        "rejected",
+        "withdrawn",
+        "in_progress",
+        "completed"
+      ]
+    },
+    "market.job_category": {
+      "name": "job_category",
+      "schema": "market",
+      "values": [
+        "agriculture",
+        "tourism",
+        "skilled_trade",
+        "domestic",
+        "logistics",
+        "handicraft"
+      ]
+    },
+    "market.job_status": {
+      "name": "job_status",
+      "schema": "market",
+      "values": [
+        "open",
+        "in_progress",
+        "completed",
+        "cancelled",
+        "expired"
       ]
     },
     "market.listing_category": {
@@ -2426,7 +3529,8 @@
         "transport",
         "education",
         "healthcare",
-        "shopping"
+        "shopping",
+        "agricultural_produce"
       ]
     },
     "market.listing_inquiry_status": {
@@ -2458,6 +3562,19 @@
         "business"
       ]
     },
+    "market.news_category": {
+      "name": "news_category",
+      "schema": "market",
+      "values": [
+        "announcement",
+        "tourism",
+        "investment",
+        "agriculture",
+        "infrastructure",
+        "culture",
+        "events"
+      ]
+    },
     "market.opportunity_status": {
       "name": "opportunity_status",
       "schema": "market",
@@ -2478,6 +3595,14 @@
         "farm_gate"
       ]
     },
+    "market.review_direction": {
+      "name": "review_direction",
+      "schema": "market",
+      "values": [
+        "worker_rates_poster",
+        "poster_rates_worker"
+      ]
+    },
     "market.transaction_type": {
       "name": "transaction_type",
       "schema": "market",
@@ -2494,6 +3619,17 @@
         "verified",
         "rejected",
         "suspended"
+      ]
+    },
+    "market.well_area": {
+      "name": "well_area",
+      "schema": "market",
+      "values": [
+        "kharga",
+        "dakhla",
+        "farafra",
+        "baris",
+        "balat"
       ]
     }
   },

--- a/services/market/drizzle/meta/_journal.json
+++ b/services/market/drizzle/meta/_journal.json
@@ -120,6 +120,13 @@
       "when": 1776053465000,
       "tag": "20260413041105_t36-employment-board",
       "breakpoints": true
+    },
+    {
+      "idx": 17,
+      "version": "7",
+      "when": 1776248229344,
+      "tag": "20260415101709_mysterious_tana_nile",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
## Summary

- **`scripts/db-reset.ts`** — new script that drops all service schemas (`identity`, `market`, `guide_booking`, `map`, `ai`) and truncates the four Drizzle migration tracking tables so the next `db:migrate` starts from a clean slate
- **`scripts/tsconfig.json`** — TypeScript project config for root-level scripts so ESLint's project service can resolve types (`postgres` and `tsx` added to root devDependencies)
- **Root `package.json`** — `db:migrate` and `db:reset` scripts; `postgres@^3.4.5` and `tsx@^4.19.0` added as devDependencies
- **`.env.example`** — documents `DATABASE_URL_LOCAL` (host-side connection string; avoids the Docker-internal hostname in `DATABASE_URL` when running scripts outside containers)
- **`Makefile`** — `db-migrate` and `db-reset` targets

**Market snapshot chain repair:** four snapshots had the same `prevId` after multiple branches merged from the same base, causing `drizzle-kit generate` to crash. Rebuilt the linear chain by patching `prevId` in the affected files. Also generates the missing `news_articles` migration (schema existed without a migration file).

## Test plan

- [x] `pnpm db:reset` — drops all schemas, clears tracking tables
- [x] `pnpm db:migrate` — all 4 services migrate cleanly from blank slate
- [x] `pnpm db:seed` — identity (14 users), market (18 news, 10 commodities, …), guide-booking, map all seed successfully
- [x] `scripts/db-reset.ts` lints clean (no `@typescript-eslint/no-unsafe-*` or `no-console` errors)