### PR TITLE
fix(market): make news migration idempotent for prod deploy

### DIFF
--- a/services/market/drizzle/20260415101709_mysterious_tana_nile.sql
+++ b/services/market/drizzle/20260415101709_mysterious_tana_nile.sql
@@ -1,5 +1,9 @@
-CREATE TYPE "market"."news_category" AS ENUM('announcement', 'tourism', 'investment', 'agriculture', 'infrastructure', 'culture', 'events');--> statement-breakpoint
-CREATE TABLE "market"."news_articles" (
+DO $$ BEGIN
+  CREATE TYPE "market"."news_category" AS ENUM('announcement', 'tourism', 'investment', 'agriculture', 'infrastructure', 'culture', 'events');
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "market"."news_articles" (
 	"id" uuid PRIMARY KEY NOT NULL,
 	"title_ar" text NOT NULL,
 	"summary_ar" text NOT NULL,
@@ -19,7 +23,10 @@ CREATE TABLE "market"."news_articles" (
 	CONSTRAINT "news_articles_slug_unique" UNIQUE("slug")
 );
 --> statement-breakpoint
-ALTER TABLE "market"."job_posts" DROP CONSTRAINT "job_posts_valid_date_range";--> statement-breakpoint
-CREATE INDEX "idx_news_category_published" ON "market"."news_articles" USING btree ("category","is_published","published_at");--> statement-breakpoint
-CREATE INDEX "idx_news_deleted_at" ON "market"."news_articles" USING btree ("deleted_at");--> statement-breakpoint
+ALTER TABLE "market"."job_posts" DROP CONSTRAINT IF EXISTS "job_posts_valid_date_range";
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_news_category_published" ON "market"."news_articles" USING btree ("category","is_published","published_at");
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_news_deleted_at" ON "market"."news_articles" USING btree ("deleted_at");
+--> statement-breakpoint
 ALTER TABLE "market"."job_posts" ADD CONSTRAINT "job_posts_valid_date_range" CHECK ("market"."job_posts"."starts_at" IS NULL OR "market"."job_posts"."ends_at" IS NULL OR "market"."job_posts"."ends_at" >= "market"."job_posts"."starts_at");


### PR DESCRIPTION
## Root cause

`d52a10b` added the news-articles schema TS files without generating a migration (the snapshot chain was broken at that point). To unblock production, `drizzle-kit push` was used to push the schema directly. This created `market.news_category` and `market.news_articles` on the production DB but did not record anything in Drizzle's tracking table.

PR #139 repaired the snapshot chain and generated migration `20260415101709_mysterious_tana_nile.sql`, which tries to `CREATE TYPE "market"."news_category"`. On production, this type already exists → deploy crashes with `PostgresError: type "news_category" already exists`.

## Fix

Made `20260415101709_mysterious_tana_nile.sql` idempotent:

- `CREATE TYPE` wrapped in a `DO $$ ... EXCEPTION WHEN duplicate_object THEN NULL; END $$;` block
- `CREATE TABLE` → `CREATE TABLE IF NOT EXISTS`
- `DROP CONSTRAINT` → `DROP CONSTRAINT IF EXISTS`
- `CREATE INDEX` → `CREATE INDEX IF NOT EXISTS`

The constraint add at the end is safe: we drop-if-exists first, then add fresh.

## Validation

- Fresh DB (`db:reset` → `db:migrate`): exit 0 ✓  
- Production simulation (type exists, migration not tracked → delete tracking record, re-run migrate): exit 0, all `IF NOT EXISTS` paths hit correctly ✓