### PR TITLE
fix: stabilize AI deploy startup health checks

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -235,7 +235,7 @@ jobs:
             docker compose run --rm -w /app/services/map map node dist/db/migrate.js
 
             echo "==> Restarting services"
-            if ! docker compose up -d --wait --timeout 300 postgres redis qdrant mongodb identity market guide-booking map ai gateway; then
+            if ! docker compose up -d --wait --timeout 600 postgres redis qdrant mongodb identity market guide-booking map ai gateway; then
               echo "==> Service health check failed; collecting diagnostics"
               docker compose ps || true
               echo "==> AI logs"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -76,7 +76,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build-images]
     environment: production
-    timeout-minutes: 12
+    timeout-minutes: 16
     permissions:
       contents: read
       packages: read

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -217,7 +217,7 @@ services:
     healthcheck:
       <<: *nestjs-healthcheck
       test: ['CMD-SHELL', 'curl -sf http://localhost:8005/health || exit 1']
-      start_period: 120s
+      start_period: 420s
       retries: 12
 
   # --- Gateway ---

--- a/services/ai/Dockerfile
+++ b/services/ai/Dockerfile
@@ -25,4 +25,4 @@ RUN groupadd --gid 1001 appuser && \
     chown -R appuser:appuser /app
 USER appuser
 
-CMD ["uv", "run", "uvicorn", "src.main:app", "--host", "0.0.0.0", "--port", "8005"]
+CMD ["/app/.venv/bin/python", "-m", "uvicorn", "src.main:app", "--host", "0.0.0.0", "--port", "8005"]


### PR DESCRIPTION
## Summary
- run the AI container from the prebuilt virtualenv instead of invoking `uv run` at runtime
- extend the AI healthcheck start period to better cover cold startup on production
- increase the first deploy `docker compose up --wait` timeout so Contabo cold boots do not fail early

## Context
The latest production deploy was no longer blocked by market migrations. It was failing because the AI container was marked unhealthy during deploy, then later became healthy on the server. This PR targets that startup timing issue.

## Test Plan
- not run locally by request
- verified statically by reviewing the deploy logs and changed configuration only