### PR TITLE
fix: restore solar map POI loading

### DIFF
--- a/apps/web/src/pages/SolarPage.spec.tsx
+++ b/apps/web/src/pages/SolarPage.spec.tsx
@@ -90,6 +90,7 @@ describe('SolarPage', () => {
   });
 
   it('requests solar installations with a backend-valid page size', () => {
+    mockUsePois.mockClear();
     renderPage();
 
     expect(mockUsePois).toHaveBeenCalledWith({

--- a/apps/web/src/pages/SolarPage.spec.tsx
+++ b/apps/web/src/pages/SolarPage.spec.tsx
@@ -89,6 +89,15 @@ describe('SolarPage', () => {
     expect(screen.getByTestId('interactive-map')).toBeDefined();
   });
 
+  it('requests solar installations with a backend-valid page size', () => {
+    renderPage();
+
+    expect(mockUsePois).toHaveBeenCalledWith({
+      category: 'solar_installation',
+      limit: 100,
+    });
+  });
+
   it('does not show irradiance legend entries when no overlay layer is rendered', () => {
     renderPage();
 

--- a/apps/web/src/pages/SolarPage.tsx
+++ b/apps/web/src/pages/SolarPage.tsx
@@ -130,7 +130,7 @@ export default function SolarPage() {
     category: 'solar_installer',
     ...(district !== 'all' ? { district } : {}),
   });
-  const { data: installationsData } = usePois({ category: 'solar_installation', limit: 200 });
+  const { data: installationsData } = usePois({ category: 'solar_installation', limit: 100 });
   const { data: benefitsData } = useBenefits();
 
   const installers = installersData?.data ?? [];


### PR DESCRIPTION
## Summary
- cap the solar community map POI request to the backend-supported limit
- add a page test that locks the solar installations query to a valid page size
- fix the production `/solar` map failure caused by `400` responses from `/api/v1/map/pois`

## Test Plan
- pnpm --filter @hena-wadeena/web test -- SolarPage.spec.tsx