### PR TITLE
fix: harden auth flows and polish navigation UX

### DIFF
--- a/apps/web/src/components/home/MissionCards.tsx
+++ b/apps/web/src/components/home/MissionCards.tsx
@@ -238,6 +238,10 @@ export function MissionCards() {
           <SR stagger className="grid grid-cols-1 gap-5 md:grid-cols-2 lg:grid-cols-4 lg:gap-7">
             {missions.map((mission) => {
               const Icon = mission.icon;
+              const hoverCopyClass =
+                mission.id === 'artisans' ? 'group-hover:text-pink-600' : 'group-hover:text-primary';
+              const ctaCopyClass = mission.id === 'artisans' ? 'text-pink-600' : 'text-primary';
+
               return (
                 <Link key={mission.id} to={mission.href}>
                   <Card
@@ -260,13 +264,17 @@ export function MissionCards() {
                       >
                         <Icon className="h-9 w-9 text-primary-foreground" strokeWidth={1.8} />
                       </div>
-                      <h3 className="mb-3 text-xl font-bold text-foreground transition-colors duration-300 group-hover:text-primary">
+                      <h3
+                        className={`mb-3 text-xl font-bold text-foreground transition-colors duration-300 ${hoverCopyClass}`}
+                      >
                         {pickLocalizedCopy(language, mission.title)}
                       </h3>
                       <p className="mb-6 flex-1 leading-relaxed text-muted-foreground">
                         {pickLocalizedCopy(language, mission.description)}
                       </p>
-                      <div className="flex items-center gap-2 font-semibold text-primary">
+                      <div
+                        className={`flex items-center gap-2 font-semibold transition-colors duration-300 ${ctaCopyClass} ${hoverCopyClass}`}
+                      >
                         {copy.cta}
                         <ArrowLeft className="h-5 w-5 transition-transform duration-300 group-hover:-translate-x-2" />
                       </div>

--- a/apps/web/src/components/home/__tests__/sections-localization.spec.tsx
+++ b/apps/web/src/components/home/__tests__/sections-localization.spec.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, within } from '@testing-library/react';
 import { MemoryRouter } from 'react-router';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -124,6 +124,25 @@ describe('Home sections localization', () => {
     expect(screen.getByText('Invest.')).toBeInTheDocument();
     expect(screen.getByText('Services for New Valley residents')).toBeInTheDocument();
     expect(screen.getAllByText('Explore').length).toBeGreaterThan(0);
+  });
+
+  it('uses pink styling for the artisans card CTA by default and on hover', () => {
+    render(
+      <MemoryRouter>
+        <MissionCards />
+      </MemoryRouter>,
+    );
+
+    const artisansTitle = screen.getByRole('heading', { name: 'Artisans' });
+    const artisansLink = artisansTitle.closest('a');
+
+    expect(artisansLink).not.toBeNull();
+    expect(artisansTitle).toHaveClass('group-hover:text-pink-600');
+
+    const exploreCta = within(artisansLink as HTMLAnchorElement).getByText('Explore');
+
+    expect(exploreCta).toHaveClass('text-pink-600');
+    expect(exploreCta).toHaveClass('group-hover:text-pink-600');
   });
 
   it('renders the Vision 2030 strip in English mode', () => {

--- a/apps/web/src/components/layout/Footer.tsx
+++ b/apps/web/src/components/layout/Footer.tsx
@@ -7,28 +7,40 @@ import { pickLocalizedCopy } from '@/lib/localization';
 
 const quickLinks = [
   {
-    href: '/tourism',
-    label: { ar: 'السياحة والمجتمع', en: 'Tourism & community' },
+    href: '/',
+    label: { ar: 'الرئيسية', en: 'Home' },
   },
   {
-    href: '/tourism/accommodation',
-    label: { ar: 'الإقامة', en: 'Accommodation' },
+    href: '/tourism',
+    label: { ar: 'السياحة', en: 'Tourism' },
   },
   {
     href: '/guides',
     label: { ar: 'المرشدين', en: 'Guides' },
   },
   {
-    href: '/marketplace',
-    label: { ar: 'البورصة والأسعار', en: 'Marketplace & prices' },
+    href: '/tourism/accommodation',
+    label: { ar: 'الإقامة', en: 'Accommodation' },
   },
   {
     href: '/logistics',
-    label: { ar: 'اللوجستيات والتنقل', en: 'Logistics & mobility' },
+    label: { ar: 'اللوجستيات', en: 'Logistics' },
+  },
+  {
+    href: '/marketplace',
+    label: { ar: 'البورصة', en: 'Marketplace' },
   },
   {
     href: '/investment',
-    label: { ar: 'فرص الاستثمار', en: 'Investment opportunities' },
+    label: { ar: 'الاستثمار', en: 'Investment' },
+  },
+  {
+    href: '/jobs',
+    label: { ar: 'التوظيف', en: 'Jobs' },
+  },
+  {
+    href: '/news',
+    label: { ar: 'أخبار', en: 'News' },
   },
 ] as const;
 
@@ -71,9 +83,9 @@ export function Footer() {
             <p className="text-sm leading-relaxed text-muted-foreground">{copy.description}</p>
           </div>
 
-          <div>
-            <h4 className="mb-4 font-semibold text-foreground">{copy.quickLinks}</h4>
-            <ul className="space-y-2 text-sm">
+          <div className="lg:justify-self-center">
+            <h4 className="mb-4 text-right font-semibold text-foreground">{copy.quickLinks}</h4>
+            <ul className="mx-auto inline-grid grid-cols-3 gap-x-4 gap-y-2 text-sm">
               {quickLinks.map((link) => (
                 <li key={link.href}>
                   <Link
@@ -116,7 +128,7 @@ export function Footer() {
               >
                 <Facebook className="h-5 w-5 shrink-0" />
                 <span className="text-sm font-bold" dir="ltr">
-                  600+
+                  700+
                 </span>
               </a>
               <a

--- a/apps/web/src/components/layout/Footer.tsx
+++ b/apps/web/src/components/layout/Footer.tsx
@@ -84,7 +84,7 @@ export function Footer() {
           </div>
 
           <div className="lg:justify-self-center">
-            <h4 className="mb-4 text-right font-semibold text-foreground">{copy.quickLinks}</h4>
+            <h4 className="mb-4 text-start font-semibold text-foreground">{copy.quickLinks}</h4>
             <ul className="mx-auto inline-grid grid-cols-3 gap-x-4 gap-y-2 text-sm">
               {quickLinks.map((link) => (
                 <li key={link.href}>

--- a/apps/web/src/components/layout/Header.tsx
+++ b/apps/web/src/components/layout/Header.tsx
@@ -25,6 +25,7 @@ import { toast } from 'sonner';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { LtrText } from '@/components/ui/ltr-text';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 import { Sheet, SheetContent, SheetTrigger } from '@/components/ui/sheet';
 import { hasRequiredRole } from '@/components/auth/access-control';
 import { useAuth } from '@/hooks/use-auth';
@@ -65,11 +66,16 @@ type HeaderCopy = {
   register: string;
   search: string;
   searchPlaceholder: string;
+  translationUnavailableAriaLabel: string;
+  translationUnavailableBody: string;
+  translationUnavailableTitle: string;
   switchToArabic: string;
   switchToEnglish: string;
   themeToggle: string;
   wallet: string;
 };
+
+const ENGLISH_TRANSLATION_UNAVAILABLE = true;
 
 const CONTROL_BUTTON_CLASS =
   'flex h-11 min-w-11 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground disabled:pointer-events-none disabled:opacity-50 md:h-9 md:min-w-9';
@@ -98,6 +104,10 @@ const headerCopy: Record<AppLanguage, HeaderCopy> = {
     register: 'إنشاء حساب',
     search: 'بحث',
     searchPlaceholder: 'بحث...',
+    translationUnavailableAriaLabel: 'الترجمة الإنجليزية غير متاحة حالياً',
+    translationUnavailableBody:
+      'نعمل حالياً على تحسين النسخة الإنجليزية. يرجى استخدام العربية في الوقت الحالي.',
+    translationUnavailableTitle: 'الترجمة الإنجليزية قيد العمل',
     switchToArabic: 'التبديل إلى العربية',
     switchToEnglish: 'Switch to English',
     themeToggle: 'تبديل الوضع',
@@ -126,6 +136,9 @@ const headerCopy: Record<AppLanguage, HeaderCopy> = {
     register: 'Create account',
     search: 'Search',
     searchPlaceholder: 'Search...',
+    translationUnavailableAriaLabel: 'English translation is currently unavailable',
+    translationUnavailableBody: 'We are improving the English version right now. Please use Arabic for the time being.',
+    translationUnavailableTitle: 'English translation in progress',
     switchToArabic: 'Switch to Arabic',
     switchToEnglish: 'Switch to English',
     themeToggle: 'Toggle theme',
@@ -146,7 +159,6 @@ function buildNavigation(language: AppLanguage): NavigationItem[] {
           investment: 'Investment',
           jobs: 'Jobs',
           news: 'News',
-          artisans: 'Artisans',
         }
       : {
           home: 'الرئيسية',
@@ -158,7 +170,6 @@ function buildNavigation(language: AppLanguage): NavigationItem[] {
           investment: 'الاستثمار',
           jobs: 'التوظيف',
           news: 'أخبار',
-          artisans: 'الحرفيات',
         };
 
   const isAccommodationPath = (pathname: string) => pathname.startsWith('/tourism/accommodation');
@@ -220,12 +231,6 @@ function buildNavigation(language: AppLanguage): NavigationItem[] {
       label: labels.news,
       matcher: (pathname) => pathname.startsWith('/news'),
     },
-    {
-      key: 'artisans',
-      href: '/artisans',
-      label: labels.artisans,
-      matcher: (pathname) => pathname.startsWith('/artisans'),
-    },
   ];
 }
 
@@ -270,18 +275,49 @@ function LanguageToggle({
 }) {
   const nextLanguage = language === 'ar' ? 'en' : 'ar';
   const title = language === 'ar' ? headerCopy.ar.switchToEnglish : headerCopy.en.switchToArabic;
+  const copy = headerCopy[language];
+  const isUnavailable = ENGLISH_TRANSLATION_UNAVAILABLE && language === 'ar';
+  const buttonClassName = `${CONTROL_BUTTON_CLASS} w-[3.125rem] gap-1 px-1.5 text-[10px] font-bold uppercase tracking-[0.16em] sm:w-12 sm:px-2 sm:text-[11px] sm:tracking-[0.18em]`;
+  const icon = (
+    <span className="relative inline-flex h-3.5 w-3.5 items-center justify-center">
+      <Languages className="h-3.5 w-3.5" />
+    </span>
+  );
+
+  if (isUnavailable) {
+    return (
+      <Popover>
+        <PopoverTrigger asChild>
+          <button
+            type="button"
+            aria-label={copy.translationUnavailableAriaLabel}
+            aria-disabled="true"
+            className={`${buttonClassName} cursor-help opacity-60 hover:bg-muted hover:text-foreground`}
+            dir="ltr"
+          >
+            {icon}
+            <span>{nextLanguage.toUpperCase()}</span>
+          </button>
+        </PopoverTrigger>
+        <PopoverContent align="center" className="w-64 space-y-1 p-3 text-sm">
+          <p className="font-semibold text-foreground">{copy.translationUnavailableTitle}</p>
+          <p className="text-muted-foreground">{copy.translationUnavailableBody}</p>
+        </PopoverContent>
+      </Popover>
+    );
+  }
 
   return (
     <button
       type="button"
       onClick={onToggle}
       disabled={disabled}
-      className={`${CONTROL_BUTTON_CLASS} w-[3.125rem] gap-1 px-1.5 text-[10px] font-bold uppercase tracking-[0.16em] sm:w-12 sm:px-2 sm:text-[11px] sm:tracking-[0.18em]`}
+      className={buttonClassName}
       aria-label={title}
       title={title}
       dir="ltr"
     >
-      <Languages className="h-3.5 w-3.5" />
+      {icon}
       <span>{nextLanguage.toUpperCase()}</span>
     </button>
   );

--- a/apps/web/src/components/layout/__tests__/Footer.spec.tsx
+++ b/apps/web/src/components/layout/__tests__/Footer.spec.tsx
@@ -40,6 +40,34 @@ describe('Footer localization', () => {
     expect(
       screen.getByText(/official digital gateway for new valley/i),
     ).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Home' })).toHaveAttribute('href', '/');
+    expect(screen.getByRole('link', { name: 'Tourism' })).toHaveAttribute('href', '/tourism');
+    expect(screen.getByRole('link', { name: 'Guides' })).toHaveAttribute('href', '/guides');
+    expect(screen.getByRole('link', { name: 'Accommodation' })).toHaveAttribute(
+      'href',
+      '/tourism/accommodation',
+    );
+    expect(screen.getByRole('link', { name: 'Logistics' })).toHaveAttribute('href', '/logistics');
+    expect(screen.getByRole('link', { name: 'Marketplace' })).toHaveAttribute(
+      'href',
+      '/marketplace',
+    );
+    expect(screen.getByRole('link', { name: 'Investment' })).toHaveAttribute(
+      'href',
+      '/investment',
+    );
+    expect(screen.getByRole('link', { name: 'Jobs' })).toHaveAttribute('href', '/jobs');
+    expect(screen.getByRole('link', { name: 'News' })).toHaveAttribute('href', '/news');
+
+    const quickLinksSection = screen.getByText('Quick links').parentElement;
+    const quickLinksList = quickLinksSection?.querySelector('ul');
+    const quickLinksHeading = screen.getByText('Quick links');
+
+    expect(quickLinksSection).toHaveClass('lg:justify-self-center');
+    expect(quickLinksList).not.toBeNull();
+    expect(quickLinksList).toHaveClass('mx-auto', 'inline-grid', 'grid-cols-3');
+    expect(quickLinksHeading).toHaveClass('text-right');
+    expect(screen.getByText('700+')).toBeInTheDocument();
     expect(screen.getByAltText('Egypt Vision 2030')).toHaveAttribute(
       'src',
       '/images/vision-2030.svg',

--- a/apps/web/src/components/layout/__tests__/Footer.spec.tsx
+++ b/apps/web/src/components/layout/__tests__/Footer.spec.tsx
@@ -66,7 +66,7 @@ describe('Footer localization', () => {
     expect(quickLinksSection).toHaveClass('lg:justify-self-center');
     expect(quickLinksList).not.toBeNull();
     expect(quickLinksList).toHaveClass('mx-auto', 'inline-grid', 'grid-cols-3');
-    expect(quickLinksHeading).toHaveClass('text-right');
+    expect(quickLinksHeading).toHaveClass('text-start');
     expect(screen.getByText('700+')).toBeInTheDocument();
     expect(screen.getByAltText('Egypt Vision 2030')).toHaveAttribute(
       'src',

--- a/apps/web/src/components/layout/__tests__/Header.spec.tsx
+++ b/apps/web/src/components/layout/__tests__/Header.spec.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -38,7 +38,7 @@ describe('Header localization', () => {
     });
   });
 
-  it('renders English guest copy when the app language is English', () => {
+  it('renders English guest copy when the app language is English without an artisans link', () => {
     mockUseAuth.mockReturnValue({
       user: null,
       isAuthenticated: false,
@@ -61,12 +61,14 @@ describe('Header localization', () => {
     expect(screen.getByAltText('Hena Wadeena')).toBeInTheDocument();
     expect(screen.getByText('Hena Wadeena')).toBeInTheDocument();
     expect(screen.getAllByLabelText('Search').length).toBeGreaterThan(0);
-    expect(screen.getByRole('link', { name: 'Artisans' })).toHaveAttribute('href', '/artisans');
+    expect(screen.queryByRole('link', { name: 'Artisans' })).not.toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Log in' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Create account' })).toBeInTheDocument();
   });
 
-  it('renders English authenticated copy when the app language is English', () => {
+  it('renders English authenticated copy when the app language is English', async () => {
+    const setLanguage = vi.fn().mockResolvedValue(undefined);
+
     mockUseAuth.mockReturnValue({
       user: {
         id: 'user-1',
@@ -86,7 +88,7 @@ describe('Header localization', () => {
       register: vi.fn(),
       logout: vi.fn(),
       updateUser: vi.fn(),
-      setLanguage: vi.fn(),
+      setLanguage,
     });
 
     render(
@@ -104,5 +106,49 @@ describe('Header localization', () => {
     expect(screen.getByText('Marketplace inquiries')).toBeInTheDocument();
     expect(screen.getByText('Notifications')).toBeInTheDocument();
     expect(screen.getByText('Log out')).toBeInTheDocument();
+
+    await act(async () => {
+      fireEvent.click(screen.getAllByRole('button', { name: 'Switch to Arabic' })[0]);
+      await Promise.resolve();
+    });
+
+    expect(setLanguage).toHaveBeenCalledWith('ar');
+  });
+
+  it('shows a popover instead of switching to English when English translation is unavailable', () => {
+    const setLanguage = vi.fn().mockResolvedValue(undefined);
+
+    mockUseAuth.mockReturnValue({
+      user: null,
+      isAuthenticated: false,
+      isLoading: false,
+      language: 'ar',
+      direction: 'rtl',
+      login: vi.fn(),
+      register: vi.fn(),
+      logout: vi.fn(),
+      updateUser: vi.fn(),
+      setLanguage,
+    });
+
+    render(
+      <MemoryRouter>
+        <Header />
+      </MemoryRouter>,
+    );
+
+    const unavailableToggle = screen.getAllByRole('button', {
+      name: 'الترجمة الإنجليزية غير متاحة حالياً',
+    })[0];
+
+    expect(unavailableToggle).toHaveAttribute('aria-disabled', 'true');
+
+    fireEvent.click(unavailableToggle);
+
+    expect(setLanguage).not.toHaveBeenCalled();
+    expect(screen.getByText('الترجمة الإنجليزية قيد العمل')).toBeInTheDocument();
+    expect(
+      screen.getByText('نعمل حالياً على تحسين النسخة الإنجليزية. يرجى استخدام العربية في الوقت الحالي.'),
+    ).toBeInTheDocument();
   });
 });

--- a/apps/web/src/pages/auth/ConfirmPasswordResetPage.tsx
+++ b/apps/web/src/pages/auth/ConfirmPasswordResetPage.tsx
@@ -25,6 +25,14 @@ function isPendingKycResponse(
 
 const SAME_PASSWORD_ERROR_MESSAGE = 'New password must be different from current password';
 const SAME_PASSWORD_ERROR_FEEDBACK = 'يجب أن تكون كلمة المرور الجديدة مختلفة عن الحالية';
+const RESET_PASSWORD_GENERIC_ERROR_FEEDBACK = 'تعذر إكمال إعادة التعيين';
+const RESET_PASSWORD_ERROR_FEEDBACK: Record<string, string> = {
+  [SAME_PASSWORD_ERROR_MESSAGE]: SAME_PASSWORD_ERROR_FEEDBACK,
+  'Invalid or expired OTP': 'رمز OTP غير صالح أو منتهي الصلاحية',
+  'OTP expired': 'انتهت صلاحية رمز OTP',
+  'Too many attempts': 'تم تجاوز عدد المحاولات المسموح بها',
+  'User not found': 'رمز OTP غير صالح أو منتهي الصلاحية',
+};
 
 export default function ConfirmPasswordResetPage() {
   const navigate = useNavigate();
@@ -71,10 +79,8 @@ export default function ConfirmPasswordResetPage() {
     } catch (error) {
       setFormError(
         error instanceof Error
-          ? error.message === SAME_PASSWORD_ERROR_MESSAGE
-            ? SAME_PASSWORD_ERROR_FEEDBACK
-            : error.message
-          : 'تعذر إكمال إعادة التعيين',
+          ? RESET_PASSWORD_ERROR_FEEDBACK[error.message] ?? RESET_PASSWORD_GENERIC_ERROR_FEEDBACK
+          : RESET_PASSWORD_GENERIC_ERROR_FEEDBACK,
       );
     } finally {
       setIsSubmitting(false);

--- a/apps/web/src/pages/auth/ConfirmPasswordResetPage.tsx
+++ b/apps/web/src/pages/auth/ConfirmPasswordResetPage.tsx
@@ -23,6 +23,9 @@ function isPendingKycResponse(
   return 'status' in response && response.status === 'pending_kyc';
 }
 
+const SAME_PASSWORD_ERROR_MESSAGE = 'New password must be different from current password';
+const SAME_PASSWORD_ERROR_FEEDBACK = 'يجب أن تكون كلمة المرور الجديدة مختلفة عن الحالية';
+
 export default function ConfirmPasswordResetPage() {
   const navigate = useNavigate();
   const auth = useAuth();
@@ -66,7 +69,13 @@ export default function ConfirmPasswordResetPage() {
       toast.success('تمت إعادة تعيين كلمة المرور بنجاح');
       void navigate('/');
     } catch (error) {
-      setFormError(error instanceof Error ? error.message : 'تعذر إكمال إعادة التعيين');
+      setFormError(
+        error instanceof Error
+          ? error.message === SAME_PASSWORD_ERROR_MESSAGE
+            ? SAME_PASSWORD_ERROR_FEEDBACK
+            : error.message
+          : 'تعذر إكمال إعادة التعيين',
+      );
     } finally {
       setIsSubmitting(false);
     }

--- a/apps/web/src/pages/auth/LoginPage.tsx
+++ b/apps/web/src/pages/auth/LoginPage.tsx
@@ -21,12 +21,17 @@ const LoginPage = () => {
   const [isLoading, setIsLoading] = useState(false);
   const [formError, setFormError] = useState<string | null>(null);
 
-  const handleSubmit = async (e: React.FormEvent) => {
+  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
+    const submittedValues = new FormData(e.currentTarget);
+    const email = String(submittedValues.get('email') ?? '').trim();
+    const password = String(submittedValues.get('password') ?? '');
+
+    setFormData({ email, password });
     setFormError(null);
     setIsLoading(true);
     try {
-      const result = await auth.login({ email: formData.email, password: formData.password });
+      const result = await auth.login({ email, password });
       if (result.status === 'pending_kyc') {
         toast.success('يجب استكمال وثائق التحقق قبل تفعيل الحساب');
         void navigate('/kyc/continue');
@@ -65,6 +70,7 @@ const LoginPage = () => {
                         <Mail className="absolute end-4 top-1/2 h-5 w-5 -translate-y-1/2 text-muted-foreground" />
                         <Input
                           id="email"
+                          name="email"
                           type="email"
                           placeholder="example@email.com"
                           value={formData.email}
@@ -75,6 +81,7 @@ const LoginPage = () => {
                             }
                           }}
                           className="h-13 rounded-xl pe-12 text-base"
+                          autoComplete="username"
                           required
                         />
                       </div>
@@ -85,6 +92,7 @@ const LoginPage = () => {
                         <Lock className="absolute end-4 top-1/2 h-5 w-5 -translate-y-1/2 text-muted-foreground" />
                         <Input
                           id="password"
+                          name="password"
                           type="password"
                           placeholder="••••••••"
                           value={formData.password}
@@ -95,6 +103,7 @@ const LoginPage = () => {
                             }
                           }}
                           className="h-13 rounded-xl pe-12 text-base"
+                          autoComplete="current-password"
                           required
                         />
                       </div>

--- a/apps/web/src/pages/auth/LoginPage.tsx
+++ b/apps/web/src/pages/auth/LoginPage.tsx
@@ -24,8 +24,10 @@ const LoginPage = () => {
   const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     const submittedValues = new FormData(e.currentTarget);
-    const email = String(submittedValues.get('email') ?? '').trim();
-    const password = String(submittedValues.get('password') ?? '');
+    const rawEmail = submittedValues.get('email');
+    const rawPassword = submittedValues.get('password');
+    const email = typeof rawEmail === 'string' ? rawEmail.trim() : '';
+    const password = typeof rawPassword === 'string' ? rawPassword : '';
 
     setFormData({ email, password });
     setFormError(null);

--- a/apps/web/src/pages/auth/__tests__/ConfirmPasswordResetPage.spec.tsx
+++ b/apps/web/src/pages/auth/__tests__/ConfirmPasswordResetPage.spec.tsx
@@ -152,4 +152,33 @@ describe('ConfirmPasswordResetPage', () => {
     expect(alert).toHaveFocus();
     expect(mockConfirmPasswordReset).not.toHaveBeenCalled();
   });
+
+  it('shows a friendly inline error when the backend rejects reusing the same password', async () => {
+    mockConfirmPasswordReset.mockRejectedValue(
+      new Error('New password must be different from current password'),
+    );
+
+    render(
+      <MemoryRouter>
+        <ConfirmPasswordResetPage />
+      </MemoryRouter>,
+    );
+
+    fireEvent.change(screen.getByLabelText('البريد الإلكتروني'), {
+      target: { value: 'user@example.com' },
+    });
+    fireEvent.change(screen.getByLabelText('رمز OTP'), {
+      target: { value: '123456' },
+    });
+    fireEvent.change(screen.getByLabelText('كلمة المرور الجديدة'), {
+      target: { value: 'same-password123' },
+    });
+    fireEvent.change(screen.getByLabelText('تأكيد كلمة المرور الجديدة'), {
+      target: { value: 'same-password123' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'تأكيد إعادة التعيين' }));
+
+    const alert = await screen.findByRole('alert');
+    expect(alert).toHaveTextContent('يجب أن تكون كلمة المرور الجديدة مختلفة عن الحالية');
+  });
 });

--- a/apps/web/src/pages/auth/__tests__/ConfirmPasswordResetPage.spec.tsx
+++ b/apps/web/src/pages/auth/__tests__/ConfirmPasswordResetPage.spec.tsx
@@ -181,4 +181,60 @@ describe('ConfirmPasswordResetPage', () => {
     const alert = await screen.findByRole('alert');
     expect(alert).toHaveTextContent('يجب أن تكون كلمة المرور الجديدة مختلفة عن الحالية');
   });
+
+  it('localizes known reset OTP errors instead of showing raw backend text', async () => {
+    mockConfirmPasswordReset.mockRejectedValue(new Error('Invalid or expired OTP'));
+
+    render(
+      <MemoryRouter>
+        <ConfirmPasswordResetPage />
+      </MemoryRouter>,
+    );
+
+    fireEvent.change(screen.getByLabelText('البريد الإلكتروني'), {
+      target: { value: 'user@example.com' },
+    });
+    fireEvent.change(screen.getByLabelText('رمز OTP'), {
+      target: { value: '123456' },
+    });
+    fireEvent.change(screen.getByLabelText('كلمة المرور الجديدة'), {
+      target: { value: 'newpassword123' },
+    });
+    fireEvent.change(screen.getByLabelText('تأكيد كلمة المرور الجديدة'), {
+      target: { value: 'newpassword123' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'تأكيد إعادة التعيين' }));
+
+    const alert = await screen.findByRole('alert');
+    expect(alert).toHaveTextContent('رمز OTP غير صالح أو منتهي الصلاحية');
+    expect(alert).not.toHaveTextContent('Invalid or expired OTP');
+  });
+
+  it('falls back to a generic Arabic error for unknown backend messages', async () => {
+    mockConfirmPasswordReset.mockRejectedValue(new Error('Some unexpected backend failure'));
+
+    render(
+      <MemoryRouter>
+        <ConfirmPasswordResetPage />
+      </MemoryRouter>,
+    );
+
+    fireEvent.change(screen.getByLabelText('البريد الإلكتروني'), {
+      target: { value: 'user@example.com' },
+    });
+    fireEvent.change(screen.getByLabelText('رمز OTP'), {
+      target: { value: '123456' },
+    });
+    fireEvent.change(screen.getByLabelText('كلمة المرور الجديدة'), {
+      target: { value: 'newpassword123' },
+    });
+    fireEvent.change(screen.getByLabelText('تأكيد كلمة المرور الجديدة'), {
+      target: { value: 'newpassword123' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'تأكيد إعادة التعيين' }));
+
+    const alert = await screen.findByRole('alert');
+    expect(alert).toHaveTextContent('تعذر إكمال إعادة التعيين');
+    expect(alert).not.toHaveTextContent('Some unexpected backend failure');
+  });
 });

--- a/apps/web/src/pages/auth/__tests__/LoginPage.spec.tsx
+++ b/apps/web/src/pages/auth/__tests__/LoginPage.spec.tsx
@@ -99,8 +99,8 @@ describe('LoginPage pending KYC flow', () => {
       </MemoryRouter>,
     );
 
-    const emailInput = screen.getByLabelText('البريد الإلكتروني') as HTMLInputElement;
-    const passwordInput = screen.getByLabelText('كلمة المرور') as HTMLInputElement;
+    const emailInput = screen.getByLabelText<HTMLInputElement>('البريد الإلكتروني');
+    const passwordInput = screen.getByLabelText<HTMLInputElement>('كلمة المرور');
 
     emailInput.value = 'resident@hena-wadeena.online';
     passwordInput.value = 'SeedDev2026!';

--- a/apps/web/src/pages/auth/__tests__/LoginPage.spec.tsx
+++ b/apps/web/src/pages/auth/__tests__/LoginPage.spec.tsx
@@ -90,6 +90,31 @@ describe('LoginPage pending KYC flow', () => {
     );
   });
 
+  it('submits the values currently shown in the inputs when the browser autofills them', async () => {
+    mockLogin.mockResolvedValue({ status: 'authenticated' });
+
+    render(
+      <MemoryRouter>
+        <LoginPage />
+      </MemoryRouter>,
+    );
+
+    const emailInput = screen.getByLabelText('البريد الإلكتروني') as HTMLInputElement;
+    const passwordInput = screen.getByLabelText('كلمة المرور') as HTMLInputElement;
+
+    emailInput.value = 'resident@hena-wadeena.online';
+    passwordInput.value = 'SeedDev2026!';
+
+    fireEvent.click(screen.getByRole('button', { name: /تسجيل الدخول/i }));
+
+    await waitFor(() => {
+      expect(mockLogin).toHaveBeenCalledWith({
+        email: 'resident@hena-wadeena.online',
+        password: 'SeedDev2026!',
+      });
+    });
+  });
+
   it('renders login failures inline and moves focus to the alert', async () => {
     mockLogin.mockRejectedValue(new Error('Invalid credentials'));
 

--- a/apps/web/src/pages/profile/ChangePasswordPage.tsx
+++ b/apps/web/src/pages/profile/ChangePasswordPage.tsx
@@ -23,6 +23,9 @@ function isPendingKycResponse(
   return 'status' in response && response.status === 'pending_kyc';
 }
 
+const SAME_PASSWORD_ERROR_MESSAGE = 'New password must be different from current password';
+const SAME_PASSWORD_ERROR_FEEDBACK = 'يجب أن تكون كلمة المرور الجديدة مختلفة عن الحالية';
+
 export default function ChangePasswordPage() {
   const navigate = useNavigate();
   const auth = useAuth();
@@ -39,6 +42,10 @@ export default function ChangePasswordPage() {
 
     if (formData.newPassword !== formData.confirmPassword) {
       setFormError('كلمتا المرور غير متطابقتين');
+      return;
+    }
+    if (formData.currentPassword === formData.newPassword) {
+      setFormError(SAME_PASSWORD_ERROR_FEEDBACK);
       return;
     }
 
@@ -64,7 +71,13 @@ export default function ChangePasswordPage() {
       toast.success('تم تغيير كلمة المرور بنجاح');
       void navigate('/profile');
     } catch (error) {
-      setFormError(error instanceof Error ? error.message : 'تعذر تغيير كلمة المرور');
+      setFormError(
+        error instanceof Error
+          ? error.message === SAME_PASSWORD_ERROR_MESSAGE
+            ? SAME_PASSWORD_ERROR_FEEDBACK
+            : error.message
+          : 'تعذر تغيير كلمة المرور',
+      );
     } finally {
       setIsSubmitting(false);
     }

--- a/apps/web/src/pages/profile/__tests__/ChangePasswordPage.spec.tsx
+++ b/apps/web/src/pages/profile/__tests__/ChangePasswordPage.spec.tsx
@@ -145,4 +145,27 @@ describe('ChangePasswordPage', () => {
     expect(alert).toHaveFocus();
     expect(mockChangePassword).not.toHaveBeenCalled();
   });
+
+  it('shows an inline error when the new password matches the current password', async () => {
+    render(
+      <MemoryRouter>
+        <ChangePasswordPage />
+      </MemoryRouter>,
+    );
+
+    fireEvent.change(screen.getByLabelText('كلمة المرور الحالية'), {
+      target: { value: 'same-password123' },
+    });
+    fireEvent.change(screen.getByLabelText('كلمة المرور الجديدة'), {
+      target: { value: 'same-password123' },
+    });
+    fireEvent.change(screen.getByLabelText('تأكيد كلمة المرور الجديدة'), {
+      target: { value: 'same-password123' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'تحديث كلمة المرور' }));
+
+    const alert = await screen.findByRole('alert');
+    expect(alert).toHaveTextContent('يجب أن تكون كلمة المرور الجديدة مختلفة عن الحالية');
+    expect(mockChangePassword).not.toHaveBeenCalled();
+  });
 });

--- a/apps/web/src/services/api.ts
+++ b/apps/web/src/services/api.ts
@@ -268,6 +268,7 @@ export interface KycOnboardingSession {
 
 export interface UpdateProfileRequest {
   full_name?: string;
+  display_name?: string | null;
   email?: string;
   phone?: string;
   avatar_url?: string;

--- a/apps/web/src/services/api.ts
+++ b/apps/web/src/services/api.ts
@@ -268,7 +268,7 @@ export interface KycOnboardingSession {
 
 export interface UpdateProfileRequest {
   full_name?: string;
-  display_name?: string | null;
+  display_name?: string;
   email?: string;
   phone?: string;
   avatar_url?: string;

--- a/apps/web/src/services/api.ts
+++ b/apps/web/src/services/api.ts
@@ -270,7 +270,6 @@ export interface UpdateProfileRequest {
   full_name?: string;
   email?: string;
   phone?: string;
-  display_name?: string;
   avatar_url?: string;
   language?: 'ar' | 'en';
 }

--- a/services/identity/src/auth/auth.service.spec.ts
+++ b/services/identity/src/auth/auth.service.spec.ts
@@ -61,6 +61,9 @@ describe('AuthService', () => {
   let mockUsersService: UsersService;
   let mockHashingService: HashingService;
   let mockDb: ReturnType<typeof createMockDb>;
+  let mockConfigService: {
+    get: ReturnType<typeof vi.fn>;
+  };
   let mockSessionService: {
     blacklistAccessToken: ReturnType<typeof vi.fn>;
     revokeRefreshToken: ReturnType<typeof vi.fn>;
@@ -105,7 +108,7 @@ describe('AuthService', () => {
         .mockReturnValue({ exp: Math.floor(Date.now() / 1000) + 900, jti: 'mock-jti' }),
     };
 
-    const mockConfigService = {
+    mockConfigService = {
       get: vi.fn((key: string, defaultVal?: string) => {
         const config: Record<string, string> = {
           JWT_REFRESH_EXPIRES_IN: '15d',
@@ -376,11 +379,12 @@ describe('AuthService', () => {
     it('should reject reusing the current password', async () => {
       vi.spyOn(mockUsersService, 'findById').mockResolvedValue(mockUser);
       vi.spyOn(mockHashingService, 'verify').mockResolvedValue(true);
+      const updatePasswordSpy = vi.spyOn(mockUsersService, 'updatePassword');
 
       await expect(authService.changePassword('user-uuid', 'oldpass', 'oldpass')).rejects.toThrow(
         BadRequestException,
       );
-      expect(mockUsersService.updatePassword).not.toHaveBeenCalled();
+      expect(updatePasswordSpy).not.toHaveBeenCalled();
     });
 
     it('still changes the password when the confirmation email fails', async () => {
@@ -425,6 +429,61 @@ describe('AuthService', () => {
       );
 
       await expect(authService.requestPasswordReset('test@example.com')).resolves.not.toThrow();
+    });
+
+    it('discards the OTP when delivery fails outside development and test', async () => {
+      mockConfigService.get.mockImplementation((key: string, defaultVal?: string) => {
+        const config: Record<string, string> = {
+          JWT_REFRESH_EXPIRES_IN: '15d',
+          NODE_ENV: 'production',
+        };
+        return config[key] ?? defaultVal;
+      });
+      vi.spyOn(mockUsersService, 'findByEmail').mockResolvedValue(mockUser);
+      vi.spyOn(authService['emailService'], 'sendPasswordResetOtp').mockRejectedValue(
+        new Error('email provider unavailable'),
+      );
+      const loggerErrorSpy = vi
+        .spyOn(authService['logger'], 'error')
+        .mockImplementation(() => undefined);
+      const loggerWarnSpy = vi
+        .spyOn(authService['logger'], 'warn')
+        .mockImplementation(() => undefined);
+      mockDb.returning.mockResolvedValueOnce([{ id: 'otp-id' }]);
+
+      await expect(authService.requestPasswordReset('test@example.com')).resolves.not.toThrow();
+
+      expect(mockDb.delete).toHaveBeenCalled();
+      expect(loggerErrorSpy).toHaveBeenCalledWith(
+        'Failed to deliver password reset OTP to test@example.com; discarded OTP record otp-id',
+      );
+      expect(loggerWarnSpy).not.toHaveBeenCalledWith(
+        expect.stringContaining('Password reset OTP for test@example.com:'),
+      );
+    });
+
+    it('does not leak the OTP to staging logs when delivery fails', async () => {
+      mockConfigService.get.mockImplementation((key: string, defaultVal?: string) => {
+        const config: Record<string, string> = {
+          JWT_REFRESH_EXPIRES_IN: '15d',
+          NODE_ENV: 'staging',
+        };
+        return config[key] ?? defaultVal;
+      });
+      vi.spyOn(mockUsersService, 'findByEmail').mockResolvedValue(mockUser);
+      vi.spyOn(authService['emailService'], 'sendPasswordResetOtp').mockRejectedValue(
+        new Error('email provider unavailable'),
+      );
+      const loggerWarnSpy = vi
+        .spyOn(authService['logger'], 'warn')
+        .mockImplementation(() => undefined);
+      mockDb.returning.mockResolvedValueOnce([{ id: 'otp-id' }]);
+
+      await expect(authService.requestPasswordReset('test@example.com')).resolves.not.toThrow();
+
+      expect(loggerWarnSpy).not.toHaveBeenCalledWith(
+        expect.stringContaining('Password reset OTP for test@example.com:'),
+      );
     });
   });
 
@@ -505,7 +564,7 @@ describe('AuthService', () => {
 
     it('should reject reusing the current password during reset', async () => {
       const hashTokenSpy = vi
-        .spyOn(authService as unknown as { hashToken(token: string): string }, 'hashToken')
+        .spyOn(authService as any, 'hashToken')
         .mockReturnValue('matching-hash');
       const otpRecord = {
         id: 'otp-id',
@@ -520,11 +579,13 @@ describe('AuthService', () => {
       mockDb.limit.mockResolvedValueOnce([otpRecord]);
       vi.spyOn(mockUsersService, 'findByEmail').mockResolvedValue(mockUser);
       vi.spyOn(mockHashingService, 'verify').mockResolvedValue(true);
+      const updatePasswordSpy = vi.spyOn(mockUsersService, 'updatePassword');
 
       await expect(
         authService.confirmPasswordReset('test@example.com', '123456', 'oldpass'),
       ).rejects.toThrow(BadRequestException);
-      expect(mockUsersService.updatePassword).not.toHaveBeenCalled();
+      expect(updatePasswordSpy).not.toHaveBeenCalled();
+      expect(mockDb.set).not.toHaveBeenCalledWith(expect.objectContaining({ usedAt: expect.any(Date) }));
       hashTokenSpy.mockRestore();
     });
 

--- a/services/identity/src/auth/auth.service.spec.ts
+++ b/services/identity/src/auth/auth.service.spec.ts
@@ -1,4 +1,9 @@
-import { ConflictException, ForbiddenException, UnauthorizedException } from '@nestjs/common';
+import {
+  BadRequestException,
+  ConflictException,
+  ForbiddenException,
+  UnauthorizedException,
+} from '@nestjs/common';
 import { UserStatus } from '@hena-wadeena/types';
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 
@@ -342,7 +347,9 @@ describe('AuthService', () => {
   describe('changePassword', () => {
     it('should change password and return new tokens', async () => {
       vi.spyOn(mockUsersService, 'findById').mockResolvedValue(mockUser);
-      vi.spyOn(mockHashingService, 'verify').mockResolvedValue(true);
+      vi.spyOn(mockHashingService, 'verify')
+        .mockResolvedValueOnce(true)
+        .mockResolvedValueOnce(false);
       mockDb.returning.mockResolvedValueOnce([{ id: 'new-token-id' }]);
       const updatePasswordSpy = vi.spyOn(mockUsersService, 'updatePassword');
       const confirmationSpy = vi.spyOn(
@@ -366,9 +373,21 @@ describe('AuthService', () => {
       );
     });
 
-    it('still changes the password when the confirmation email fails', async () => {
+    it('should reject reusing the current password', async () => {
       vi.spyOn(mockUsersService, 'findById').mockResolvedValue(mockUser);
       vi.spyOn(mockHashingService, 'verify').mockResolvedValue(true);
+
+      await expect(authService.changePassword('user-uuid', 'oldpass', 'oldpass')).rejects.toThrow(
+        BadRequestException,
+      );
+      expect(mockUsersService.updatePassword).not.toHaveBeenCalled();
+    });
+
+    it('still changes the password when the confirmation email fails', async () => {
+      vi.spyOn(mockUsersService, 'findById').mockResolvedValue(mockUser);
+      vi.spyOn(mockHashingService, 'verify')
+        .mockResolvedValueOnce(true)
+        .mockResolvedValueOnce(false);
       vi.spyOn(mockUsersService, 'updatePassword').mockResolvedValue(undefined);
       vi.spyOn(authService['emailService'], 'sendPasswordChangedConfirmation').mockRejectedValue(
         new Error('email provider unavailable'),
@@ -398,6 +417,15 @@ describe('AuthService', () => {
 
       await expect(authService.requestPasswordReset('nope@example.com')).resolves.not.toThrow();
     });
+
+    it('still succeeds when the reset OTP email cannot be sent', async () => {
+      vi.spyOn(mockUsersService, 'findByEmail').mockResolvedValue(mockUser);
+      vi.spyOn(authService['emailService'], 'sendPasswordResetOtp').mockRejectedValue(
+        new Error('email provider unavailable'),
+      );
+
+      await expect(authService.requestPasswordReset('test@example.com')).resolves.not.toThrow();
+    });
   });
 
   describe('confirmPasswordReset', () => {
@@ -417,6 +445,7 @@ describe('AuthService', () => {
       };
       mockDb.limit.mockResolvedValueOnce([otpRecord]);
       vi.spyOn(mockUsersService, 'findByEmail').mockResolvedValue(mockUser);
+      vi.spyOn(mockHashingService, 'verify').mockResolvedValue(false);
       mockDb.returning.mockResolvedValueOnce([{ id: 'new-token-id' }]);
       const updatePasswordSpy = vi.spyOn(mockUsersService, 'updatePassword');
       const confirmationSpy = vi.spyOn(
@@ -474,6 +503,31 @@ describe('AuthService', () => {
       ).rejects.toThrow(UnauthorizedException);
     });
 
+    it('should reject reusing the current password during reset', async () => {
+      const hashTokenSpy = vi
+        .spyOn(authService as unknown as { hashToken(token: string): string }, 'hashToken')
+        .mockReturnValue('matching-hash');
+      const otpRecord = {
+        id: 'otp-id',
+        target: 'test@example.com',
+        purpose: 'reset' as const,
+        codeHash: 'matching-hash',
+        expiresAt: new Date(Date.now() + 600000),
+        usedAt: null,
+        attempts: 0,
+        createdAt: new Date(),
+      };
+      mockDb.limit.mockResolvedValueOnce([otpRecord]);
+      vi.spyOn(mockUsersService, 'findByEmail').mockResolvedValue(mockUser);
+      vi.spyOn(mockHashingService, 'verify').mockResolvedValue(true);
+
+      await expect(
+        authService.confirmPasswordReset('test@example.com', '123456', 'oldpass'),
+      ).rejects.toThrow(BadRequestException);
+      expect(mockUsersService.updatePassword).not.toHaveBeenCalled();
+      hashTokenSpy.mockRestore();
+    });
+
     it('still resets the password when the confirmation email fails', async () => {
       const hashTokenSpy = vi
         .spyOn(authService as any, 'hashToken')
@@ -490,6 +544,7 @@ describe('AuthService', () => {
       };
       mockDb.limit.mockResolvedValueOnce([otpRecord]);
       vi.spyOn(mockUsersService, 'findByEmail').mockResolvedValue(mockUser);
+      vi.spyOn(mockHashingService, 'verify').mockResolvedValue(false);
       vi.spyOn(authService['emailService'], 'sendPasswordResetConfirmation').mockRejectedValue(
         new Error('email provider unavailable'),
       );

--- a/services/identity/src/auth/auth.service.spec.ts
+++ b/services/identity/src/auth/auth.service.spec.ts
@@ -505,7 +505,9 @@ describe('AuthService', () => {
       mockDb.limit.mockResolvedValueOnce([otpRecord]);
       vi.spyOn(mockUsersService, 'findByEmail').mockResolvedValue(mockUser);
       vi.spyOn(mockHashingService, 'verify').mockResolvedValue(false);
-      mockDb.returning.mockResolvedValueOnce([{ id: 'new-token-id' }]);
+      mockDb.returning
+        .mockResolvedValueOnce([{ id: 'otp-id' }])
+        .mockResolvedValueOnce([{ id: 'new-token-id' }]);
       const updatePasswordSpy = vi.spyOn(mockUsersService, 'updatePassword');
       const confirmationSpy = vi.spyOn(
         authService['emailService'],
@@ -589,6 +591,33 @@ describe('AuthService', () => {
       hashTokenSpy.mockRestore();
     });
 
+    it('should reject the reset if the OTP was consumed concurrently', async () => {
+      const hashTokenSpy = vi
+        .spyOn(authService as any, 'hashToken')
+        .mockReturnValue('matching-hash');
+      const otpRecord = {
+        id: 'otp-id',
+        target: 'test@example.com',
+        purpose: 'reset' as const,
+        codeHash: 'matching-hash',
+        expiresAt: new Date(Date.now() + 600000),
+        usedAt: null,
+        attempts: 0,
+        createdAt: new Date(),
+      };
+      mockDb.limit.mockResolvedValueOnce([otpRecord]);
+      vi.spyOn(mockUsersService, 'findByEmail').mockResolvedValue(mockUser);
+      vi.spyOn(mockHashingService, 'verify').mockResolvedValue(false);
+      mockDb.returning.mockResolvedValueOnce([]);
+      const updatePasswordSpy = vi.spyOn(mockUsersService, 'updatePassword');
+
+      await expect(
+        authService.confirmPasswordReset('test@example.com', '123456', 'newpass123'),
+      ).rejects.toThrow(UnauthorizedException);
+      expect(updatePasswordSpy).not.toHaveBeenCalled();
+      hashTokenSpy.mockRestore();
+    });
+
     it('still resets the password when the confirmation email fails', async () => {
       const hashTokenSpy = vi
         .spyOn(authService as any, 'hashToken')
@@ -606,6 +635,9 @@ describe('AuthService', () => {
       mockDb.limit.mockResolvedValueOnce([otpRecord]);
       vi.spyOn(mockUsersService, 'findByEmail').mockResolvedValue(mockUser);
       vi.spyOn(mockHashingService, 'verify').mockResolvedValue(false);
+      mockDb.returning
+        .mockResolvedValueOnce([{ id: 'otp-id' }])
+        .mockResolvedValueOnce([{ id: 'new-token-id' }]);
       vi.spyOn(authService['emailService'], 'sendPasswordResetConfirmation').mockRejectedValue(
         new Error('email provider unavailable'),
       );

--- a/services/identity/src/auth/auth.service.spec.ts
+++ b/services/identity/src/auth/auth.service.spec.ts
@@ -618,6 +618,29 @@ describe('AuthService', () => {
       hashTokenSpy.mockRestore();
     });
 
+    it('should not reveal whether a reset target still has a user account', async () => {
+      const hashTokenSpy = vi
+        .spyOn(authService as any, 'hashToken')
+        .mockReturnValue('matching-hash');
+      const otpRecord = {
+        id: 'otp-id',
+        target: 'test@example.com',
+        purpose: 'reset' as const,
+        codeHash: 'matching-hash',
+        expiresAt: new Date(Date.now() + 600000),
+        usedAt: null,
+        attempts: 0,
+        createdAt: new Date(),
+      };
+      mockDb.limit.mockResolvedValueOnce([otpRecord]);
+      vi.spyOn(mockUsersService, 'findByEmail').mockResolvedValue(null);
+
+      await expect(
+        authService.confirmPasswordReset('test@example.com', '123456', 'newpass123'),
+      ).rejects.toThrow('Invalid or expired OTP');
+      hashTokenSpy.mockRestore();
+    });
+
     it('still resets the password when the confirmation email fails', async () => {
       const hashTokenSpy = vi
         .spyOn(authService as any, 'hashToken')

--- a/services/identity/src/auth/auth.service.ts
+++ b/services/identity/src/auth/auth.service.ts
@@ -337,7 +337,12 @@ export class AuthService {
       throw new BadRequestException('New password must be different from current password');
     }
 
-    await this.db.update(otpCodes).set({ usedAt: new Date() }).where(eq(otpCodes.id, otpRecord.id));
+    const [consumedOtp] = await this.db
+      .update(otpCodes)
+      .set({ usedAt: new Date() })
+      .where(and(eq(otpCodes.id, otpRecord.id), isNull(otpCodes.usedAt)))
+      .returning({ id: otpCodes.id });
+    if (!consumedOtp) throw new UnauthorizedException('Invalid or expired OTP');
 
     const passwordHash = await this.hashingService.hash(newPassword);
     await this.usersService.updatePassword(user.id, passwordHash);

--- a/services/identity/src/auth/auth.service.ts
+++ b/services/identity/src/auth/auth.service.ts
@@ -9,6 +9,7 @@ import {
   requiresKycForRole,
 } from '@hena-wadeena/types';
 import {
+  BadRequestException,
   ConflictException,
   ForbiddenException,
   Inject,
@@ -250,6 +251,10 @@ export class AuthService {
 
     const valid = await this.hashingService.verify(user.passwordHash, currentPassword);
     if (!valid) throw new UnauthorizedException('Invalid current password');
+    const isReusedPassword = await this.hashingService.verify(user.passwordHash, newPassword);
+    if (isReusedPassword) {
+      throw new BadRequestException('New password must be different from current password');
+    }
 
     const passwordHash = await this.hashingService.hash(newPassword);
     await this.usersService.updatePassword(userId, passwordHash);
@@ -276,7 +281,13 @@ export class AuthService {
       expiresAt: new Date(Date.now() + 10 * 60 * 1000),
     });
 
-    await this.emailService.sendPasswordResetOtp(email, otp);
+    const emailSent = await this.deliverEmailSafely('password reset OTP', () =>
+      this.emailService.sendPasswordResetOtp(email, otp),
+    );
+
+    if (!emailSent && (this.configService.get<string>('NODE_ENV') ?? 'development') !== 'production') {
+      this.logger.warn(`Password reset OTP for ${email}: ${otp}`);
+    }
   }
 
   async confirmPasswordReset(
@@ -311,6 +322,10 @@ export class AuthService {
       this.usersService.findByEmail(email),
     ]);
     if (!user) throw new UnauthorizedException('User not found');
+    const isReusedPassword = await this.hashingService.verify(user.passwordHash, newPassword);
+    if (isReusedPassword) {
+      throw new BadRequestException('New password must be different from current password');
+    }
 
     const passwordHash = await this.hashingService.hash(newPassword);
     await this.usersService.updatePassword(user.id, passwordHash);
@@ -496,12 +511,14 @@ export class AuthService {
     });
   }
 
-  private async deliverEmailSafely(label: string, send: () => Promise<void>) {
+  private async deliverEmailSafely(label: string, send: () => Promise<void>): Promise<boolean> {
     try {
       await send();
+      return true;
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       this.logger.warn(`Failed to send ${label}: ${message}`);
+      return false;
     }
   }
 }

--- a/services/identity/src/auth/auth.service.ts
+++ b/services/identity/src/auth/auth.service.ts
@@ -273,20 +273,33 @@ export class AuthService {
 
     const otp = this.generateOtp();
     const codeHash = this.hashToken(otp);
+    const environment = this.configService.get<string>('NODE_ENV') ?? 'development';
+    const shouldLogOtp = environment === 'development' || environment === 'test';
 
-    await this.db.insert(otpCodes).values({
-      target: email,
-      purpose: 'reset',
-      codeHash,
-      expiresAt: new Date(Date.now() + 10 * 60 * 1000),
-    });
+    const [otpRecord] = await this.db
+      .insert(otpCodes)
+      .values({
+        target: email,
+        purpose: 'reset',
+        codeHash,
+        expiresAt: new Date(Date.now() + 10 * 60 * 1000),
+      })
+      .returning({ id: otpCodes.id });
 
     const emailSent = await this.deliverEmailSafely('password reset OTP', () =>
       this.emailService.sendPasswordResetOtp(email, otp),
     );
 
-    if (!emailSent && (this.configService.get<string>('NODE_ENV') ?? 'development') !== 'production') {
+    if (!emailSent && shouldLogOtp) {
       this.logger.warn(`Password reset OTP for ${email}: ${otp}`);
+      return;
+    }
+
+    if (!emailSent && otpRecord) {
+      await this.db.delete(otpCodes).where(eq(otpCodes.id, otpRecord.id));
+      this.logger.error(
+        `Failed to deliver password reset OTP to ${email}; discarded OTP record ${otpRecord.id}`,
+      );
     }
   }
 
@@ -317,15 +330,14 @@ export class AuthService {
       throw new UnauthorizedException('Invalid OTP');
     }
 
-    const [, user] = await Promise.all([
-      this.db.update(otpCodes).set({ usedAt: new Date() }).where(eq(otpCodes.id, otpRecord.id)),
-      this.usersService.findByEmail(email),
-    ]);
+    const user = await this.usersService.findByEmail(email);
     if (!user) throw new UnauthorizedException('User not found');
     const isReusedPassword = await this.hashingService.verify(user.passwordHash, newPassword);
     if (isReusedPassword) {
       throw new BadRequestException('New password must be different from current password');
     }
+
+    await this.db.update(otpCodes).set({ usedAt: new Date() }).where(eq(otpCodes.id, otpRecord.id));
 
     const passwordHash = await this.hashingService.hash(newPassword);
     await this.usersService.updatePassword(user.id, passwordHash);

--- a/services/identity/src/auth/auth.service.ts
+++ b/services/identity/src/auth/auth.service.ts
@@ -331,7 +331,7 @@ export class AuthService {
     }
 
     const user = await this.usersService.findByEmail(email);
-    if (!user) throw new UnauthorizedException('User not found');
+    if (!user) throw new UnauthorizedException('Invalid or expired OTP');
     const isReusedPassword = await this.hashingService.verify(user.passwordHash, newPassword);
     if (isReusedPassword) {
       throw new BadRequestException('New password must be different from current password');

--- a/services/identity/src/test-utils/create-mock-db.ts
+++ b/services/identity/src/test-utils/create-mock-db.ts
@@ -13,6 +13,7 @@ interface MockDbChain {
   returning: Mock;
   onConflictDoNothing: Mock;
   update: Mock;
+  delete: Mock;
   set: Mock;
   orderBy: Mock;
   execute: Mock;
@@ -36,6 +37,7 @@ export function createMockDb(): MockDbChain {
     returning: vi.fn().mockResolvedValue([]),
     onConflictDoNothing: vi.fn(),
     update: vi.fn(),
+    delete: vi.fn(),
     set: vi.fn(),
     orderBy: vi.fn(),
     execute: vi.fn().mockResolvedValue([]),
@@ -55,6 +57,7 @@ export function createMockDb(): MockDbChain {
   chain.insert.mockReturnValue(chain);
   chain.values.mockReturnValue(chain);
   chain.update.mockReturnValue(chain);
+  chain.delete.mockReturnValue(chain);
   chain.onConflictDoNothing.mockReturnValue(chain);
   chain.set.mockReturnValue(chain);
   chain.orderBy.mockReturnValue(chain);

--- a/services/identity/src/users/dto/update-profile.dto.ts
+++ b/services/identity/src/users/dto/update-profile.dto.ts
@@ -65,6 +65,7 @@ const phoneField = z
 
 const updateProfileSchema = z.object({
   full_name: z.string().trim().min(1).max(100).optional(),
+  display_name: z.string().trim().min(1).max(100).optional(),
   email: emailField.optional(),
   phone: phoneField.optional(),
   avatar_url: avatarUrlField.optional(),

--- a/services/identity/src/users/dto/update-profile.dto.ts
+++ b/services/identity/src/users/dto/update-profile.dto.ts
@@ -67,7 +67,6 @@ const updateProfileSchema = z.object({
   full_name: z.string().trim().min(1).max(100).optional(),
   email: emailField.optional(),
   phone: phoneField.optional(),
-  display_name: z.string().trim().max(100).optional(),
   avatar_url: avatarUrlField.optional(),
   language: z.enum(['ar', 'en']).optional(),
 });

--- a/services/identity/src/users/users.controller.ts
+++ b/services/identity/src/users/users.controller.ts
@@ -53,6 +53,7 @@ export class UsersController {
   async updateMe(@CurrentUser() user: JwtPayload, @Body() dto: UpdateProfileDto) {
     const updated = await this.usersService.updateProfile(user.sub, {
       fullName: dto.full_name,
+      displayName: dto.display_name,
       email: dto.email,
       phone: dto.phone,
       avatarUrl: dto.avatar_url,

--- a/services/identity/src/users/users.controller.ts
+++ b/services/identity/src/users/users.controller.ts
@@ -55,7 +55,6 @@ export class UsersController {
       fullName: dto.full_name,
       email: dto.email,
       phone: dto.phone,
-      displayName: dto.display_name,
       avatarUrl: dto.avatar_url,
       language: dto.language,
     });

--- a/services/identity/test/auth.e2e-spec.ts
+++ b/services/identity/test/auth.e2e-spec.ts
@@ -154,6 +154,16 @@ describe('Auth (e2e)', () => {
       expect(res.body.fullName).toBe('Updated User Name');
       expect(res.body.language).toBe('en');
     });
+
+    it('should accept display_name updates for backwards compatibility', async () => {
+      const res = await request(app.getHttpServer())
+        .patch('/api/v1/auth/me')
+        .set('Authorization', `Bearer ${accessToken}`)
+        .send({ display_name: 'Updated Display Name' })
+        .expect(200);
+
+      expect(res.body.displayName).toBe('Updated Display Name');
+    });
   });
 
   describe('POST /api/v1/auth/refresh', () => {
@@ -307,6 +317,15 @@ describe('Auth (e2e)', () => {
         .post('/api/v1/auth/password-reset/confirm')
         .send({ email: testEmail, otp: latestResetOtp, new_password: 'newpassword456' })
         .expect(400);
+
+      const [record] = await db
+        .select()
+        .from(otpCodes)
+        .where(and(eq(otpCodes.target, testEmail), eq(otpCodes.purpose, 'reset')))
+        .orderBy(desc(otpCodes.createdAt))
+        .limit(1);
+
+      expect(record?.usedAt).toBeNull();
     });
 
     it('should reject an expired OTP', async () => {

--- a/services/identity/test/auth.e2e-spec.ts
+++ b/services/identity/test/auth.e2e-spec.ts
@@ -148,10 +148,10 @@ describe('Auth (e2e)', () => {
       const res = await request(app.getHttpServer())
         .patch('/api/v1/auth/me')
         .set('Authorization', `Bearer ${accessToken}`)
-        .send({ display_name: 'Updated Name', language: 'en' })
+        .send({ full_name: 'Updated User Name', language: 'en' })
         .expect(200);
 
-      expect(res.body.displayName).toBe('Updated Name');
+      expect(res.body.fullName).toBe('Updated User Name');
       expect(res.body.language).toBe('en');
     });
   });
@@ -242,6 +242,14 @@ describe('Auth (e2e)', () => {
         .send({ current_password: 'totally-wrong-password', new_password: 'anotherpass123' })
         .expect(401);
     });
+
+    it('should reject reusing the current password', async () => {
+      await request(app.getHttpServer())
+        .post('/api/v1/auth/change-password')
+        .set('Authorization', `Bearer ${accessToken}`)
+        .send({ current_password: newPassword, new_password: newPassword })
+        .expect(400);
+    });
   });
 
   describe('POST /api/v1/auth/logout', () => {
@@ -290,6 +298,15 @@ describe('Auth (e2e)', () => {
         .post('/api/v1/auth/password-reset/confirm')
         .send({ email: testEmail, otp: '000000', new_password: resetPassword })
         .expect(401);
+    });
+
+    it('should reject reusing the current password during reset', async () => {
+      expect(latestResetOtp).toMatch(/^\d{6}$/);
+
+      await request(app.getHttpServer())
+        .post('/api/v1/auth/password-reset/confirm')
+        .send({ email: testEmail, otp: latestResetOtp, new_password: 'newpassword456' })
+        .expect(400);
     });
 
     it('should reject an expired OTP', async () => {


### PR DESCRIPTION
## Summary
- reject password reuse across password change and reset flows, with friendlier inline feedback in the web auth pages
- submit browser-autofilled login values correctly and align profile updates with `full_name` only
- polish the header, footer, and home mission CTA UX, including the temporary English-toggle notice and updated quick links

## Test Plan
- `pnpm --filter @hena-wadeena/web test -- src/components/layout/__tests__/Header.spec.tsx src/components/layout/__tests__/Footer.spec.tsx src/components/home/__tests__/sections-localization.spec.tsx src/pages/auth/__tests__/LoginPage.spec.tsx src/pages/auth/__tests__/ConfirmPasswordResetPage.spec.tsx src/pages/profile/__tests__/ChangePasswordPage.spec.tsx`
- `pnpm --filter @hena-wadeena/identity test -- src/auth/auth.service.spec.ts`
- `pnpm --filter @hena-wadeena/identity test:e2e -- test/auth.e2e-spec.ts`