### PR TITLE
fix(wallet): send idempotency key for top-ups

### DIFF
--- a/apps/web/src/lib/__tests__/wallet-store.spec.ts
+++ b/apps/web/src/lib/__tests__/wallet-store.spec.ts
@@ -50,7 +50,7 @@ describe('wallet-store', () => {
     expect(snapshot.wallet.recent_transactions).toEqual([bookingTransaction]);
   });
 
-  it('includes an idempotency key when topping up the wallet', async () => {
+  it('uses the caller-provided idempotency key when topping up the wallet', async () => {
     paymentsAPI.topUp.mockResolvedValue({
       success: true,
       data: { balance: 32500 },
@@ -66,11 +66,11 @@ describe('wallet-store', () => {
       },
     });
 
-    await topUpWallet('user-1', 2500);
+    await topUpWallet('user-1', 2500, 'wallet:topup:user-1:intent-1');
 
     expect(paymentsAPI.topUp).toHaveBeenCalledWith({
       amount: 2500,
-      idempotency_key: expect.stringMatching(/^wallet:topup:user-1:/),
+      idempotency_key: 'wallet:topup:user-1:intent-1',
     });
   });
 });

--- a/apps/web/src/lib/__tests__/wallet-store.spec.ts
+++ b/apps/web/src/lib/__tests__/wallet-store.spec.ts
@@ -10,7 +10,7 @@ vi.mock('@/services/api', () => ({
   paymentsAPI,
 }));
 
-import { getWalletSnapshot } from '../wallet-store';
+import { getWalletSnapshot, topUpWallet } from '../wallet-store';
 
 describe('wallet-store', () => {
   beforeEach(() => {
@@ -48,5 +48,29 @@ describe('wallet-store', () => {
     expect(snapshot.wallet.balance).toBe(30000);
     expect(snapshot.transactions).toEqual([bookingTransaction]);
     expect(snapshot.wallet.recent_transactions).toEqual([bookingTransaction]);
+  });
+
+  it('includes an idempotency key when topping up the wallet', async () => {
+    paymentsAPI.topUp.mockResolvedValue({
+      success: true,
+      data: { balance: 32500 },
+    });
+    paymentsAPI.getWallet.mockResolvedValue({
+      success: true,
+      data: {
+        id: 'wallet-user-1',
+        user_id: 'user-1',
+        balance: 32500,
+        currency: 'EGP',
+        recent_transactions: [],
+      },
+    });
+
+    await topUpWallet('user-1', 2500);
+
+    expect(paymentsAPI.topUp).toHaveBeenCalledWith({
+      amount: 2500,
+      idempotency_key: expect.stringMatching(/^wallet:topup:user-1:/),
+    });
   });
 });

--- a/apps/web/src/lib/wallet-store.ts
+++ b/apps/web/src/lib/wallet-store.ts
@@ -6,6 +6,10 @@ const DEFAULT_TOP_UP_DESCRIPTION = 'شحن المحفظة';
 const DEFAULT_CURRENCY = 'EGP';
 const LEGACY_BOOKING_REFERENCE_TYPES = new Set(['package_booking', 'package_booking_refund']);
 
+function createWalletTopUpIdempotencyKey(userId: string): string {
+  return `wallet:topup:${userId}:${crypto.randomUUID()}`;
+}
+
 type StoredWalletState = {
   wallet: Wallet;
   transactions: Transaction[];
@@ -156,7 +160,10 @@ export async function topUpWallet(
     throw new Error('amountPiasters must be a positive integer');
   }
 
-  const response = await paymentsAPI.topUp(amountPiasters);
+  const response = await paymentsAPI.topUp({
+    amount: amountPiasters,
+    idempotency_key: createWalletTopUpIdempotencyKey(userId),
+  });
   if (!response.success) {
     throw new Error('فشل شحن المحفظة');
   }

--- a/apps/web/src/lib/wallet-store.ts
+++ b/apps/web/src/lib/wallet-store.ts
@@ -6,10 +6,6 @@ const DEFAULT_TOP_UP_DESCRIPTION = 'شحن المحفظة';
 const DEFAULT_CURRENCY = 'EGP';
 const LEGACY_BOOKING_REFERENCE_TYPES = new Set(['package_booking', 'package_booking_refund']);
 
-function createWalletTopUpIdempotencyKey(userId: string): string {
-  return `wallet:topup:${userId}:${crypto.randomUUID()}`;
-}
-
 type StoredWalletState = {
   wallet: Wallet;
   transactions: Transaction[];
@@ -153,6 +149,7 @@ export async function getWalletSnapshot(userId: string): Promise<StoredWalletSta
 export async function topUpWallet(
   userId: string,
   amountPiasters: number,
+  idempotencyKey: string,
   description = DEFAULT_TOP_UP_DESCRIPTION,
   reference?: { reference_id?: string; reference_type?: string },
 ): Promise<StoredWalletState> {
@@ -162,7 +159,7 @@ export async function topUpWallet(
 
   const response = await paymentsAPI.topUp({
     amount: amountPiasters,
-    idempotency_key: createWalletTopUpIdempotencyKey(userId),
+    idempotency_key: idempotencyKey,
   });
   if (!response.success) {
     throw new Error('فشل شحن المحفظة');

--- a/apps/web/src/pages/profile/WalletPage.tsx
+++ b/apps/web/src/pages/profile/WalletPage.tsx
@@ -14,6 +14,10 @@ import { useAuth } from '@/hooks/use-auth';
 import { formatPrice } from '@/lib/format';
 import { getWalletSnapshot, parseEgpInputToPiasters, topUpWallet } from '@/lib/wallet-store';
 
+function createWalletTopUpIdempotencyKey(userId: string) {
+  return `wallet:topup:${userId}:${crypto.randomUUID()}`;
+}
+
 const WalletPage = () => {
   const { user } = useAuth();
   const [wallet, setWallet] = useState<WalletType | null>(null);
@@ -21,6 +25,10 @@ const WalletPage = () => {
   const [topupAmount, setTopupAmount] = useState('');
   const [showTopup, setShowTopup] = useState(false);
   const [loading, setLoading] = useState(true);
+  const [pendingTopupIntent, setPendingTopupIntent] = useState<{
+    amountPiasters: number;
+    idempotencyKey: string;
+  } | null>(null);
 
   const refreshWallet = useCallback(async () => {
     if (!user) {
@@ -55,12 +63,18 @@ const WalletPage = () => {
     }
 
     setLoading(true);
+    const idempotencyKey =
+      pendingTopupIntent?.amountPiasters === amountPiasters
+        ? pendingTopupIntent.idempotencyKey
+        : createWalletTopUpIdempotencyKey(user.id);
+    setPendingTopupIntent({ amountPiasters, idempotencyKey });
     try {
-      const snapshot = await topUpWallet(user.id, amountPiasters);
+      const snapshot = await topUpWallet(user.id, amountPiasters, idempotencyKey);
       setWallet(snapshot.wallet);
       setTransactions(snapshot.transactions);
       setShowTopup(false);
       setTopupAmount('');
+      setPendingTopupIntent(null);
       toast.success('تم شحن المحفظة بنجاح');
     } catch (error: unknown) {
       toast.error(error instanceof Error ? error.message : 'تعذر شحن المحفظة');
@@ -129,7 +143,10 @@ const WalletPage = () => {
                           variant="outline"
                           size="sm"
                           className="hover:scale-[1.05] transition-transform rounded-lg"
-                          onClick={() => setTopupAmount(String(amt))}
+                          onClick={() => {
+                            setTopupAmount(String(amt));
+                            setPendingTopupIntent(null);
+                          }}
                         >
                           {amt}
                         </Button>
@@ -141,7 +158,10 @@ const WalletPage = () => {
                       step="0.01"
                       placeholder="مبلغ آخر..."
                       value={topupAmount}
-                      onChange={(e) => setTopupAmount(e.target.value)}
+                      onChange={(e) => {
+                        setTopupAmount(e.target.value);
+                        setPendingTopupIntent(null);
+                      }}
                       className="h-12 rounded-xl"
                     />
                     <div className="flex gap-3">
@@ -155,7 +175,10 @@ const WalletPage = () => {
                       <Button
                         variant="outline"
                         className="h-12 rounded-xl"
-                        onClick={() => setShowTopup(false)}
+                        onClick={() => {
+                          setShowTopup(false);
+                          setPendingTopupIntent(null);
+                        }}
                       >
                         إلغاء
                       </Button>

--- a/apps/web/src/pages/profile/__tests__/WalletPage.spec.tsx
+++ b/apps/web/src/pages/profile/__tests__/WalletPage.spec.tsx
@@ -1,0 +1,133 @@
+import type { ReactNode } from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import WalletPage from '../WalletPage';
+
+const mockGetWalletSnapshot = vi.fn();
+const mockTopUpWallet = vi.fn();
+const mockToastSuccess = vi.fn();
+const mockToastError = vi.fn();
+const mockRandomUuid = vi.fn();
+
+vi.mock('@/components/layout/Layout', () => ({
+  Layout: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock('@/components/motion/PageTransition', () => ({
+  PageTransition: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  GradientMesh: () => null,
+}));
+
+vi.mock('@/components/motion/ScrollReveal', () => ({
+  SR: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock('@/components/motion/Skeleton', () => ({
+  Skeleton: () => null,
+}));
+
+vi.mock('@/hooks/use-auth', () => ({
+  useAuth: () => ({
+    user: {
+      id: 'user-1',
+      email: 'resident@hena-wadeena.online',
+    },
+  }),
+}));
+
+vi.mock('@/lib/format', () => ({
+  formatPrice: (value: number) => String(value),
+}));
+
+vi.mock('@/lib/wallet-store', () => ({
+  getWalletSnapshot: (...args: unknown[]) => mockGetWalletSnapshot(...args),
+  parseEgpInputToPiasters: (value: string) => {
+    const amount = Number(value);
+    return Number.isFinite(amount) ? amount * 100 : null;
+  },
+  topUpWallet: (...args: unknown[]) => mockTopUpWallet(...args),
+}));
+
+vi.mock('sonner', () => ({
+  toast: {
+    success: (...args: unknown[]) => mockToastSuccess(...args),
+    error: (...args: unknown[]) => mockToastError(...args),
+  },
+}));
+
+describe('WalletPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetWalletSnapshot.mockResolvedValue({
+      wallet: {
+        id: 'wallet-user-1',
+        user_id: 'user-1',
+        balance: 0,
+        currency: 'EGP',
+        recent_transactions: [],
+      },
+      transactions: [],
+    });
+
+    mockRandomUuid.mockReset();
+    mockRandomUuid
+      .mockReturnValueOnce('idem-1')
+      .mockReturnValueOnce('idem-2')
+      .mockReturnValueOnce('idem-3');
+    vi.spyOn(globalThis.crypto, 'randomUUID').mockImplementation(() => mockRandomUuid());
+  });
+
+  it('reuses the same idempotency key when the user retries the same top-up', async () => {
+    mockTopUpWallet
+      .mockRejectedValueOnce(new Error('network error'))
+      .mockResolvedValueOnce({
+        wallet: {
+          id: 'wallet-user-1',
+          user_id: 'user-1',
+          balance: 10000,
+          currency: 'EGP',
+          recent_transactions: [],
+        },
+        transactions: [],
+      });
+
+    render(
+      <MemoryRouter>
+        <WalletPage />
+      </MemoryRouter>,
+    );
+
+    await screen.findByText('الرصيد الحالي');
+
+    fireEvent.click(screen.getByRole('button', { name: 'شحن المحفظة' }));
+    fireEvent.change(screen.getByPlaceholderText('مبلغ آخر...'), {
+      target: { value: '100' },
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'شحن الآن' }));
+
+    await waitFor(() =>
+      expect(mockTopUpWallet).toHaveBeenNthCalledWith(
+        1,
+        'user-1',
+        10000,
+        'wallet:topup:user-1:idem-1',
+      ),
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'شحن الآن' }));
+
+    await waitFor(() =>
+      expect(mockTopUpWallet).toHaveBeenNthCalledWith(
+        2,
+        'user-1',
+        10000,
+        'wallet:topup:user-1:idem-1',
+      ),
+    );
+
+    expect(mockRandomUuid).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/src/services/api.ts
+++ b/apps/web/src/services/api.ts
@@ -1443,10 +1443,10 @@ export interface Transaction {
 
 export const paymentsAPI = {
   getWallet: () => apiFetchWithRefresh<{ success: boolean; data: Wallet }>('/wallet'),
-  topUp: (amount: number) =>
+  topUp: (data: { amount: number; idempotency_key: string }) =>
     apiFetchWithRefresh<{ success: boolean; data: { balance: number } }>('/wallet/topup', {
       method: 'POST',
-      body: JSON.stringify({ amount }),
+      body: JSON.stringify(data),
     }),
   deduct: (data: {
     amount: number;


### PR DESCRIPTION
## Summary
- send an `idempotency_key` with wallet top-up requests from the web app
- update the wallet API client to post the full top-up payload shape expected by the identity service
- add a regression test covering the top-up request contract

## Verification
- `pnpm --filter @hena-wadeena/web test -- src/lib/__tests__/wallet-store.spec.ts`
- `pnpm --filter @hena-wadeena/web typecheck`

## Context
The identity service requires `amount` and `idempotency_key` for `/api/v1/wallet/topup`. The web app was only sending `amount`, which caused wallet top-up failures.